### PR TITLE
Add arm64 platform to Gemfile.lock for M1 macs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
       power_assert
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 


### PR DESCRIPTION
This was added after a `bundle install` on an M1 mac. I am not entirely sure if there are other implications of merging this :thinking: