### PR TITLE
Add execution context

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -8,6 +8,7 @@ require_relative "yarv/putself"
 
 module YARV
   Main = Object.new
+  ExecutionContext = Struct.new(:stack)
 
   class InstructionSequence
     attr_reader :selfo, :insns
@@ -35,7 +36,8 @@ module YARV
 
     def emulate
       stack = []
-      insns.each { |insn| insn.execute(stack) }
+      context = ExecutionContext.new(stack)
+      insns.each { |insn| insn.execute(context) }
     end
   end
 

--- a/lib/yarv/leave.rb
+++ b/lib/yarv/leave.rb
@@ -20,7 +20,7 @@ module YARV
   # ~~~
   #
   class Leave
-    def execute(stack)
+    def execute(context)
       # skip for now
     end
 

--- a/lib/yarv/opt_plus.rb
+++ b/lib/yarv/opt_plus.rb
@@ -24,9 +24,9 @@ module YARV
   # ~~~
   #
   class OptPlus
-    def execute(stack)
-      left, right = stack.pop(2)
-      stack.push(left + right)
+    def execute(context)
+      left, right = context.stack.pop(2)
+      context.stack.push(left + right)
     end
 
     def pretty_print(q)

--- a/lib/yarv/opt_send_without_block.rb
+++ b/lib/yarv/opt_send_without_block.rb
@@ -30,9 +30,9 @@ module YARV
       @argc = argc
     end
 
-    def execute(stack)
-      receiver, *arguments = stack.pop(argc + 1)
-      stack.push(receiver.send(mid, *arguments))
+    def execute(context)
+      receiver, *arguments = context.stack.pop(argc + 1)
+      context.stack.push(receiver.send(mid, *arguments))
     end
 
     def pretty_print(q)

--- a/lib/yarv/putobject.rb
+++ b/lib/yarv/putobject.rb
@@ -26,8 +26,8 @@ module YARV
       @object = object
     end
 
-    def execute(stack)
-      stack.push(object)
+    def execute(context)
+      context.stack.push(object)
     end
 
     def pretty_print(q)

--- a/lib/yarv/putself.rb
+++ b/lib/yarv/putself.rb
@@ -28,10 +28,10 @@ module YARV
       @object = object
     end
 
-    def execute(stack)
-      stack.push(object)
+    def execute(context)
+      context.stack.push(object)
     end
-  
+
     def pretty_print(q)
       q.text("putself")
     end


### PR DESCRIPTION
In order to work on `branchif` - https://github.com/kddnewton/yarv/issues/23, we need to have access to a program counter when the instruction is being executed. 

This PR adds an execution context that will contain the program counter later on. 