### PR TITLE
Add a program counter to ExecutionContext

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -18,10 +18,12 @@ module YARV
   class ExecutionContext
     attr_reader :stack
     attr_reader :globals
+    attr_accessor :program_counter
 
     def initialize
       @stack = []
       @globals = {}
+      @program_counter = 0
     end
   end
 
@@ -63,7 +65,10 @@ module YARV
 
     def emulate
       context = ExecutionContext.new
-      insns.each { |insn| insn.execute(context) }
+      insns.each do |insn|
+        insn.execute(context)
+        context.program_counter += 1
+      end
     end
   end
 


### PR DESCRIPTION
Again, in order to start implementing `branchif`, we need a program counter in the ExecutionContext. 

This PR adds the program counter that increments after each instruction is executed. 

Note that the program counter does not match how CRuby defines a program counter. We'll come back to it eventually. 