### PR TITLE
Implement `branchunless`

### DIFF
--- a/lib/yarv/branchunless.rb
+++ b/lib/yarv/branchunless.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `branchunless` has one argument, the jump index
+  # and pops one value off the stack, the jump condition.
+  #
+  # If the value popped off the stack is false,
+  # `branchunless` jumps to the jump index and continues executing there.
+  #
+  # ### TracePoint
+  #
+  # There is no trace point for `branchunless`.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # if 2+3; puts 'foo'; end
+  #
+  # == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,22)> (catch: FALSE)
+  # 0000 putobject                              2                         (   1)[Li]
+  # 0002 putobject                              3
+  # 0004 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr]
+  # 0006 branchunless                           14
+  # 0008 putself
+  # 0009 putstring                              "hi"
+  # 0011 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
+  # 0013 leave
+  # 0014 putnil
+  # 0015 leave
+  # ~~~
+  #
+  class BranchUnless
+    def initialize(label)
+      @label = label
+    end
+
+    attr_reader :label
+
+    def execute(context)
+      condition = context.stack.pop
+      unless condition
+        jump_index = context.iseq.labels[label]
+        context.program_counter = jump_index
+      end
+    end
+
+    def pretty_print(q)
+      q.text("branchunless #{label.inspect}")
+    end
+  end
+end

--- a/test/branchunless_test.rb
+++ b/test/branchunless_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "./test_case"
+
+module YARV
+  class BranchUnlessTest < TestCase
+    def test_branchunless_jumps_if_false
+      source_code = "if 2+3; puts 'foo'; end"
+      assert_insns(
+        [PutObject, PutObject, OptPlus, BranchUnless, PutSelf, PutString, OptSendWithoutBlock, Leave, Leave],
+        source_code)
+      assert_stdout("foo\n", source_code)
+    end
+
+    def test_branchunless_doesnt_jump_if_true
+      source_code = "if 'bar'.empty?; puts 'foo'; end"
+      assert_insns(
+        [PutString, OptEmptyP, BranchUnless, PutSelf, PutString, OptSendWithoutBlock, Leave, Leave],
+        source_code)
+      assert_stdout("", source_code)
+    end
+  end
+end


### PR DESCRIPTION
There are couple notable changes made in this commit:
- Program counter is now being used to determine which instruction to be executed next
- We're now appending instructions to an array. This is so we can get the instruction's index for the label lookup hash.
- `ExecutionContext` has access to the `InstructionSequence` it's executing

Co-authored-by: Tom Stuart <tom.stuart@shopify.com>
Co-authored-by: Adrianna Chang <adrianna.chang@shopify.com>
Co-authored-by: Kevin Newton <kevin.newton@shopify.com>