### PR TITLE
Fix value of __FILE__ in mspec

### DIFF
--- a/exe/yarv
+++ b/exe/yarv
@@ -4,4 +4,4 @@
 $:.unshift(File.expand_path("../lib", __dir__))
 require "yarv"
 
-YARV.emulate(ARGF.read)
+YARV.compile(ARGF.read, filename: ARGF.filename).emulate

--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -197,10 +197,11 @@ module YARV
     end
   end
 
-  def self.compile(source)
+  def self.compile(source, filename: nil)
     iseq =
       RubyVM::InstructionSequence.compile(
         source,
+        filename,
         inline_const_cache: true,
         peephole_optimization: true,
         specialized_instruction: true,


### PR DESCRIPTION
When we compile the instruction sequence, `__FILE__` will get evaluated at
compile time so we need to pass it to the compiler when we are compiling
a file.