### PR TITLE
Implement `opt_regexpmatch2`

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -344,6 +344,8 @@ module YARV
           @insns << OptOr.new(CallData.new(:|, 1, flag))
         in :opt_plus, { mid: :+, orig_argc: 1, flag: }
           @insns << OptPlus.new(CallData.new(:+, 1, flag))
+        in :opt_regexpmatch2, { mid: :=~, orig_argc: 1 }
+          @insns << OptRegexpmatch2.new
         in :opt_send_without_block, { mid:, orig_argc:, flag: }
           @insns << OptSendWithoutBlock.new(CallData.new(mid, orig_argc, flag))
         in :opt_setinlinecache, cache

--- a/lib/yarv/opt_regexpmatch2.rb
+++ b/lib/yarv/opt_regexpmatch2.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `opt_regexpmatch2` is a specialization of the `opt_send_without_block` instruction
+  # that occurs when the `=~` operator is used.
+  #
+  # ### TracePoint
+  #
+  # `opt_regexpmatch2` can dispatch both the `c_call` and `c_return` events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # /a/ =~ "a"
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,10)> (catch: FALSE)
+  # 0000 putobject                              /a/                       (   1)[Li]
+  # 0002 putstring                              "a"
+  # 0004 opt_regexpmatch2                       <calldata!mid:=~, argc:1, ARGS_SIMPLE>[CcCr]
+  # 0006 leave
+  # ~~~
+  #
+  class OptRegexpmatch2
+    def call(context)
+      left, right = context.stack.pop(2)
+
+      result = context.call_method(left, :=~, [right])
+      context.stack.push(result)
+    end
+
+    def pretty_print(q)
+      q.text("opt_regexpmatch2 <calldata!mid:=~, argc:1, ARGS_SIMPLE>")
+    end
+  end
+end

--- a/test/opt_regexpmatch2_test.rb
+++ b/test/opt_regexpmatch2_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module YARV
+  class OptRegexpmatch2Test < TestCase
+    def test_execute
+      # # should work with string and regexp literals
+      # assert_insns([PutString, PutObject, OptRegexpmatch2, Leave], "'str' =~ /regexp/")
+      # assert_insns([PutObject, PutString, OptRegexpmatch2, Leave], "/regexp/ =~ 'str'")
+
+      # # should work with variables
+      # assert_insns([PutSelf, OptSendWithoutBlock, PutObject, OptRegexpmatch2, Leave], "var =~ /regexp/")
+      # assert_insns([PutSelf, OptSendWithoutBlock, PutObject, OptRegexpmatch2, Leave], "/regexp/ =~ var")
+      # assert_insns([PutSelf, OptSendWithoutBlock, PutSelf, OptSendWithoutBlock, OptRegexpmatch2, Leave], "var =~ var")
+
+      # # should work with object instances without out-of-the-box support
+      # assert_insns([PutObjectInt2Fix0, PutObject, OptRegexpmatch2, Leave], "0 =~ /0/")
+
+      # usage
+      assert_stdout("0\n", "p 'str' =~ /str/")
+      assert_stdout("1\n", "p 'str' =~ /tr/")
+      assert_stdout("nil\n", "p 'str' =~ /blah/")
+      assert_stdout("0\n", "p (/str/) =~ 'str'")
+      assert_stdout("1\n", "p (/tr/) =~ 'str'")
+      assert_stdout("nil\n", "p (/blah/) =~ 'str'")
+    end
+  end
+end


### PR DESCRIPTION
Closes #97 

This is a draft PR because the commented `assert_insns` tests are currently inoperative, for reasons unclear to me.

Each test yields a result like

```
Failure: test_execute(YARV::OptRegexpmatch2Test)
/Users/sloop/code/yarv/test/test_case.rb:13:in `assert_insns'
/Users/sloop/code/yarv/test/opt_regexpmatch2_test.rb:9:in `test_execute'
      6:   class OptRegexpmatch2Test < TestCase
      7:     def test_execute
      8:       # # should work with string and regexp literals
  =>  9:       assert_insns([PutString, PutObject, OptRegexpmatch2, Leave], "'str' =~ /regexp/")
     10:       assert_insns([PutObject, PutString, OptRegexpmatch2, Leave], "/regexp/ =~ 'str'")
     11:
     12:       # # should work with variables
<[YARV::PutString, YARV::PutObject, YARV::OptRegexpmatch2, YARV::Leave]> expected but was
<[YARV::PutString, YARV::PutObject, YARV::OptSendWithoutBlock, YARV::Leave]>
```

i.e. the emulator is pushing an `opt_send_without_block` instruction rather than the expected `opt_regexpmatch2` instruction.

This is not reflective of the results I'm seeing from the insns dump:

```sh
$ ruby --dump=insns -e "'str' =~ /regexp/"

== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,17)> (catch: FALSE)
0000 putstring                              "str"                     (   1)[Li]
0002 putobject                              /regexp/
0004 opt_regexpmatch2                       <calldata!mid:=~, argc:1, ARGS_SIMPLE>[CcCr]
0006 leave
```

or the VM compilation dump:

```rb
# $ RubyVM::InstructionSequence.compile("'str' =~ /regexp/").to_a
# =>
["YARVInstructionSequence/SimpleDataFormat",
 3,
 1,
 1,
 {:arg_size=>0, :local_size=>0, :stack_max=>2, :node_id=>3, :code_location=>[1, 0, 1, 17], :node_ids=>[0, 1, 2, -1]},
 "<compiled>",
 "<compiled>",
 "<compiled>",
 1,
 :top,
 [],
 {},
 [],
 [1, :RUBY_EVENT_LINE, [:putstring, "str"], [:putobject, /regexp/], [:opt_regexpmatch2, {:mid=>:=~, :flag=>16, :orig_argc=>1}], [:leave]]]
```

For reference I'm using the latest stable ruby:

```sh
$ ruby -v
=> ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
```