### PR TITLE
Implement concatarray

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -142,6 +142,8 @@ module YARV
           @labels[insn] = @insns.length
         in :branchunless, value
           @insns << BranchUnless.new(value)
+        in [:concatarray]
+          @insns << ConcatArray.new
         in :definemethod, name, iseq
           @insns << DefineMethod.new(name, InstructionSequence.new(selfo, iseq))
         in [:dup]

--- a/lib/yarv/concatarray.rb
+++ b/lib/yarv/concatarray.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `concatarray` concatenates the two Arrays on top of the stack.
+  #
+  # It coerces the two objects at the top of the stack into Arrays by calling
+  # `to_a` if necessary, and makes sure to `dup` the first Array if it was
+  # already an Array, to avoid mutating it when concatenating.
+  #
+  # ### TracePoint
+  #
+  # `concatarray` can dispatch the `line` and `call` events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # [1,*2]
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,6)> (catch: FALSE)
+  # # 0000 duparray                               [1]                       (   1)[Li]
+  # # 0002 putobject                              2
+  # # 0004 concatarray
+  # # 0005 leave
+  # ~~~
+  #
+  class ConcatArray
+    def call(context)
+      left, right = context.stack.pop(2)
+      coerced_left = coerce(left)
+      coerced_left = left.dup if coerced_left.equal?(left)
+      coerced_left.concat(coerce(right))
+      context.stack.push(coerced_left)
+    end
+
+    private
+
+    def coerce(object)
+      if object.respond_to?(:to_a)
+        object.to_a
+      else
+        [object]
+      end
+    end
+  end
+end

--- a/test/concatarray_test.rb
+++ b/test/concatarray_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module YARV
+  class ConcatarrayTest < TestCase
+    def test_execute
+      assert_insns([DupArray, PutObject, ConcatArray, Leave], "[1,*2]")
+      assert_stdout("[1, 2]\n", "p [1, *2]")
+    end
+
+    def test_coerces_the_left_element
+      assert_stdout_for_instructions(
+        "[2, 3]\n",
+        [
+          [:putself],
+          [:putobject, 2],
+          [:putobject, 3],
+          [:concatarray],
+          [:opt_send_without_block, { mid: :p, flag: 20, orig_argc: 1 }]
+        ]
+      )
+    end
+
+    def test_duplicates_the_left_element
+      assert_stdout_for_instructions(
+        "[1]\n",
+        [
+          [:putself],
+          [:duparray, [1]],
+          [:dup],
+          [:putobject, 2],
+          [:concatarray],
+          [:pop],
+          [:opt_send_without_block, { mid: :p, flag: 20, orig_argc: 1 }]
+        ]
+      )
+    end
+  end
+end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -22,5 +22,17 @@ module YARV
     ensure
       $stdout = original
     end
+
+    # Allows to test instructions sequences that the compiler doesn't generate.
+    def assert_stdout_for_instructions(expected, instructions)
+      original = $stdout
+      $stdout = StringIO.new
+      iseq = RubyVM::InstructionSequence.compile("").to_a
+      iseq[-1] = [1, :RUBY_EVENT_LINE, *instructions, [:leave]]
+      InstructionSequence.new(Main.new, iseq).eval
+      assert_equal(expected, $stdout.string)
+    ensure
+      $stdout = original
+    end
   end
 end


### PR DESCRIPTION
Fixes #100 

To test some of the features I copied from the implementation of MRI [`vm_concat_array`](https://github.com/ruby/ruby/blob/a85cdb5a6e7d735b03eb5ae80e5ac0c5424eb259/vm_insnhelper.c#L4347), I had to generate my own instruction sequence.

That's because, from what I can see, MRI will always have a duparray/.../concatarray or newarray/...concatarray so the left/deepest object will always be an Array that could safely be used directly without coercion/duplication.

Let me know if you think of another way to test those.