### PR TITLE
Allow compile options to be specified in tests

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -242,11 +242,7 @@ module YARV
     file = "<compiled>",
     path = "<compiled>",
     lineno = 1,
-    inline_const_cache: true,
-    peephole_optimization: true,
-    specialized_instruction: true,
-    tailcall_optimization: false,
-    trace_instruction: false
+    **options
   )
     iseq =
       RubyVM::InstructionSequence.compile(
@@ -254,13 +250,18 @@ module YARV
         file,
         path,
         lineno,
-        inline_const_cache: inline_const_cache,
-        peephole_optimization: peephole_optimization,
-        specialized_instruction: specialized_instruction,
-        tailcall_optimization: tailcall_optimization,
-        trace_instruction: trace_instruction
+        **default_compile_options.merge!(options)
       )
-
     InstructionSequence.new(Main.new, iseq.to_a)
+  end
+
+  def self.default_compile_options
+    {
+      inline_const_cache: true,
+      peephole_optimization: true,
+      specialized_instruction: true,
+      tailcall_optimization: false,
+      trace_instruction: false
+    }
   end
 end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -8,16 +8,16 @@ module YARV
   class TestCase < Test::Unit::TestCase
     private
 
-    def assert_insns(expected, code)
-      iseq = YARV.compile(code)
+    def assert_insns(expected, code, **options)
+      iseq = YARV.compile(code, **options)
       assert_equal(expected, iseq.insns.map(&:class))
     end
 
-    def assert_stdout(expected, code)
+    def assert_stdout(expected, code, **options)
       original = $stdout
       $stdout = StringIO.new
 
-      YARV.compile(code).eval
+      YARV.compile(code, **options).eval
       assert_equal(expected, $stdout.string)
     ensure
       $stdout = original


### PR DESCRIPTION
There are a couple of tests where we'd like to set certain compile options on `RubyVM::InstructionSequence` in order to produce the `insns` we want. For example, setting `peephole_optimization: false` allows us to write simpler tests for some of the branch instructions.

This PR allows compile options to be passed to the `assert_insns` and `assert_stdout` test helpers.