### PR TITLE
WIP: Implement putspecialobject

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -364,6 +364,8 @@ module YARV
           @insns << PutSelf.new(selfo)
         in :putstring, string
           @insns << PutString.new(string)
+        in :putspecialobject, type
+          @insns << PutSpecialObject.new(type)
         in :setglobal, name
           @insns << SetGlobal.new(name)
         in :setlocal_WC_0, offset
@@ -371,6 +373,8 @@ module YARV
           @insns << SetLocalWC0.new(locals[index], index)
         in [:swap]
           @insns << Swap.new
+        in [:defineclass, name, stuff, num]
+          @insns << -> (arg) {}
         end
       end
     end

--- a/lib/yarv/putspecialobject.rb
+++ b/lib/yarv/putspecialobject.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `putspecialobject` is an instruction that pushes an object representing a
+  # scope onto the stack. This scope is used by the instructions that follow.
+  #
+  #  The value passed to `putspecialobject` corresponds to the enum members of
+  #  `vm_special_object_type`. They are:
+  #
+  # - 1. `VM_SPECIAL_OBJECT_VMCORE`. This is an object created at the start of
+  #      VM initialization that defines some basic functionality.
+  # - 2. `VM_SPECIAL_OBJECT_CBASE`.
+  # - 3. `VM_SPECIAL_OBJECT_CONST_BASE`. 
+  # ### TracePoint
+  #
+  # `putspecialobject` can dispatch the line event.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # alias :foobar :!
+  #
+  # #== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,14)> (catch: FALSE)
+  # #0000 putspecialobject                       3                         (   1)[Li]
+  # #0002 putnil
+  # #0003 defineclass                            :Foo, <class:Foo>, 0
+  # #0007 leave
+  # #
+  # #== disasm: #<ISeq:<class:Foo>@-e:1 (1,0)-(1,14)> (catch: FALSE)
+  # #0000 putnil                                                           (   1)[Cl]
+  # #0001 leave    
+  # ~~~
+  #
+  class PutSpecialObject
+    attr_reader :type
+
+    def initialize(type)
+      @object = type
+    end
+
+    def call(context)
+      if type == 3 
+        context.stack.push(context.current_frame)
+      end
+    end
+
+    def pretty_print(q)
+      q.text("putobject #{object.inspect}")
+    end
+  end
+end

--- a/test/putspecialobject_test.rb
+++ b/test/putspecialobject_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module YARV
+  class PutSpecialObjectTest < TestCase
+    def test_execute
+      assert_insns([PutSpecialObject, Proc, Leave], "class Foo; end")
+      assert_stdout("", "class Foo; end")
+    end
+  end
+end


### PR DESCRIPTION
@tomajwinter and I started looking at `putspecialobject`( #74 ). We have a question:

* What's the difference between `VM_SPECIAL_OBJECT_CBASE`, and `VM_SPECIAL_OBJECT_CONST_BASE`? It looks like one of them is walking up the frame stack and the other isn't, but I'm not 100% on this.

Also note: We've faked out `defineclass` here with an empty lambda in order to get the tests to work...