### PR TITLE
Implement `opt_str_freeze`

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -192,6 +192,8 @@ module YARV
           @insns << OptSendWithoutBlock.new(mid, orig_argc)
         in :opt_setinlinecache, cache
           @insns << OptSetInlineCache.new(cache)
+        in :opt_str_freeze, value, { mid: :freeze, orig_argc: 0 }
+          @insns << OptStrFreeze.new(value)
         in :opt_str_uminus, value, { mid: :-@, orig_argc: 0 }
           @insns << OptStrUMinus.new(value)
         in :opt_succ, { mid: :succ, orig_argc: 0 }

--- a/lib/yarv/opt_str_freeze.rb
+++ b/lib/yarv/opt_str_freeze.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `opt_str_freeze` pushes a frozen known string value with no interpolation
+  # onto the stack.
+  #
+  # ### TracePoint
+  #
+  # `opt_str_freeze` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # 'hello'.freeze
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,14)> (catch: FALSE)
+  # # 0000 opt_str_freeze                         "hello", <calldata!mid:freeze, argc:0, ARGS_SIMPLE>(   1)[Li]
+  # # 0003 leave
+  # ~~~
+  #
+  class OptStrFreeze
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+
+    def call(context)
+      result = context.call_method(value, :freeze, [])
+      context.stack.push(result)
+    end
+
+    def pretty_print(q)
+      q.text(
+        "opt_str_freeze #{value.inspect} <calldata!mid:freeze, argc:0, ARGS_SIMPLE>"
+      )
+    end
+  end
+end

--- a/test/opt_str_freeze_test.rb
+++ b/test/opt_str_freeze_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module YARV
+  class OptStrFreezeTest < TestCase
+    def test_execute
+      assert_insns([OptStrFreeze, Leave], "\"string\".freeze")
+      assert_stdout("\"string\"\n", "p(-'string')")
+    end
+  end
+end


### PR DESCRIPTION
Closes #116.
Closes #3.

Comes with the same caveats as #24 in terms of testing strategy: we should revisit when `leave` / method dispatch is fully implemented.