### PR TITLE
Fix workflow on rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,8 @@
 name: Main
 on:
-- push
-- pull_request_target
+  push:
+    branches: main
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Previously was running CI on every push to every branch, and also
running on the main branch when it was the target of a pull request.

Now it only runs on pushes to main, and on pull requests (sources).

See rubygems example: https://github.com/rubygems/rubygems/blob/3f39b2fc2dcd68e0b7f0adc84cfa08c2794747be/.github/workflows/bundler.yml#L3-L9