### PR TITLE
Implement `branchnil`

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -140,6 +140,8 @@ module YARV
           # skip for now
         in Symbol
           @labels[insn] = @insns.length
+        in :branchnil, value
+          @insns << BranchNil.new(value)
         in :branchunless, value
           @insns << BranchUnless.new(value)
         in [:concatarray]

--- a/lib/yarv/branchnil.rb
+++ b/lib/yarv/branchnil.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `branchnil` has one argument: the jump index. It pops one value off the stack:
+  # the jump condition.
+  #
+  # If the value popped off the stack is nil, `branchnil` jumps to
+  # the jump index and continues executing there.
+  #
+  # ### TracePoint
+  #
+  # There is no trace point for `branchnil`.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # x = nil; if x&.to_s; puts 'hi'; end
+  #
+  # # == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,35)> (catch: FALSE)
+  # # local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+  # # [ 1] x@0
+  # # 0000 putnil                                                           (   1)[Li]
+  # # 0001 setlocal_WC_0                          x@0
+  # # 0003 getlocal_WC_0                          x@0
+  # # 0005 dup
+  # # 0006 branchnil                              10
+  # # 0008 opt_send_without_block                 <calldata!mid:to_s, argc:0, ARGS_SIMPLE>
+  # # 0010 branchunless                           18
+  # # 0012 putself
+  # # 0013 putstring                              "hi"
+  # # 0015 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0017 leave
+  # # 0018 putnil
+  # # 0019 leave
+  # ~~~
+  #
+  class BranchNil
+    def initialize(label)
+      @label = label
+    end
+
+    def call(context)
+      condition = context.stack.pop
+
+      if condition.nil?
+        jump_index = context.current_iseq.labels[label]
+        context.program_counter = jump_index
+      end
+    end
+
+    def pretty_print(q)
+      q.text("branchnil #{label.inspect}")
+    end
+
+    private
+
+    attr_reader :label
+  end
+end

--- a/lib/yarv/branchunless.rb
+++ b/lib/yarv/branchunless.rb
@@ -6,7 +6,7 @@ module YARV
   # `branchunless` has one argument, the jump index
   # and pops one value off the stack, the jump condition.
   #
-  # If the value popped off the stack is false,
+  # If the value popped off the stack is false or nil,
   # `branchunless` jumps to the jump index and continues executing there.
   #
   # ### TracePoint

--- a/test/branchnil_test.rb
+++ b/test/branchnil_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "./test_case"
+
+module YARV
+  class BranchNilTest < TestCase
+    def test_branchnil_jumps_if_nil
+      source_code = "x = nil; if x&.to_s; puts 'hi'; end"
+      assert_insns(
+        [
+          PutNil,
+          SetLocalWC0,
+          GetLocalWC0,
+          Dup,
+          BranchNil,
+          OptSendWithoutBlock,
+          BranchUnless,
+          PutSelf,
+          PutString,
+          OptSendWithoutBlock,
+          Leave,
+          PutNil,
+          Leave
+        ],
+        source_code
+      )
+      assert_stdout("", source_code)
+    end
+
+    def test_branchnil_doesnt_jump_if_not_nil
+      source_code = "x = true; puts x&.to_s"
+      assert_insns(
+        [
+          PutObject,
+          SetLocalWC0,
+          PutSelf,
+          GetLocalWC0,
+          Dup,
+          BranchNil,
+          OptSendWithoutBlock,
+          OptSendWithoutBlock,
+          Leave
+        ],
+        source_code
+      )
+      assert_stdout("true\n", source_code)
+    end
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/kddnewton/yarv/issues/115

Similar to the other branch instructions, pops a condition off the stack to evaluate, and then changes the control flow if the condition is nil.