### PR TITLE
Implement special insns via `GetLocal`/`SetLocal`

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -308,7 +308,10 @@ module YARV
         in :putstring, string
           @insns << PutString.new(string)
         in :send, { mid:, orig_argc:, flag: }, block_iseq
-          @insns << Send.new(CallData.new(mid, orig_argc, flag), InstructionSequence.new(selfo, block_iseq))
+          @insns << Send.new(
+            CallData.new(mid, orig_argc, flag),
+            InstructionSequence.new(selfo, block_iseq)
+          )
         in :setglobal, name
           @insns << SetGlobal.new(name)
         in :setlocal_WC_0, offset

--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -240,6 +240,10 @@ module YARV
           @insns << NewHash.new(size)
         in :opt_and, { mid: :&, orig_argc: 1, flag: }
           @insns << OptAnd.new(CallData.new(:&, 1, flag))
+        in :opt_aset, { mid: :[]=, orig_argc: 2, flag: }
+          @insns << OptAset.new(CallData.new(:[]=, 2, flag))
+        in :opt_aset_with, key, { mid: :[]=, orig_argc: 2, flag: }
+          @insns << OptAsetWith.new(CallData.new(:[]=, 2, flag))
         in :opt_aref, { mid: :[], orig_argc: 1, flag: }
           @insns << OptAref.new(CallData.new(:[], 1, flag))
         in :opt_aref_with, key, { mid: :[], orig_argc: 1, flag: }

--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -125,7 +125,7 @@ module YARV
     # simply the popped values off the top of the stack. It is the
     # responsibility of this method to ensure that they get copied into the
     # locals table in the correct order.
-    def call_method(call_data, receiver, arguments, &block)
+    def call_method(call_data, receiver, arguments)
       if (method = methods[[receiver.class, call_data.mid]])
         # We only support a subset of the valid argument permutations. This
         # validates each kind to make sure we don't accidentally try to handle a
@@ -147,7 +147,7 @@ module YARV
 
         stack.last
       else
-        receiver.send(call_data.mid, *arguments, &block)
+        receiver.send(call_data.mid, *arguments)
       end
     end
 

--- a/lib/yarv/getlocal.rb
+++ b/lib/yarv/getlocal.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `getlocal` instruction fetches the value of a local variable from the
+  # frame at a given depth below the current frame, determined by the depth
+  # and the index given as its arguments.
+  #
+  # ### TracePoint
+  #
+  # `getlocal` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # value = 5
+  # Proc.new do
+  #   Proc.new do
+  #     value
+  #   end
+  # end
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,42)> (catch: FALSE)
+  # # local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+  # # [ 1] value@0
+  # # 0000 putobject                              2                         (   1)[Li]
+  # # 0001 setlocal_WC_0                          value@0
+  # # 0003 opt_getinlinecache                     12, <is:0>
+  # # 0006 putobject                              true
+  # # 0008 getconstant                            :Proc
+  # # 0010 opt_setinlinecache                     <is:0>
+  # # 0012 send                                   <calldata!mid:new, argc:0>, block in <main>
+  # # 0015 leave
+  # #
+  # # == disasm: #<ISeq:block in <main>@-e:1 (1,20)-(1,42)> (catch: FALSE)
+  # # 0000 opt_getinlinecache                     9, <is:0>                 (   1)[LiBc]
+  # # 0003 putobject                              true
+  # # 0005 getconstant                            :Proc
+  # # 0007 opt_setinlinecache                     <is:0>
+  # # 0009 send                                   <calldata!mid:new, argc:0>, block (2 levels) in <main>
+  # # 0012 leave                                  [Br]
+  # #
+  # # == disasm: #<ISeq:block (2 levels) in <main>@-e:1 (1,31)-(1,40)> (catch: FALSE)
+  # # 0000 getlocal                               value@0, 2                (   1)[LiBc]
+  # # 0003 leave                                  [Br]
+  # ~~~
+  #
+  class GetLocal
+    attr_reader :name, :index, :depth
+
+    def initialize(name, index, depth)
+      @name = name
+      @index = index
+      @depth = depth
+    end
+
+    def call(context)
+      frames = pop_frames_from_context
+
+      value = context.current_frame.get_local(index)
+      context.stack.push(value)
+
+      push_frames_to_context(frames)
+    end
+
+    def to_s
+      "%-38s %s@%d" % [instruction_name, name, index]
+    end
+
+    private
+
+    def pop_frames_from_context
+      depth.times.with_object([]) do |frame, frames|
+        frames << context.frames.pop
+      end
+    end
+
+    def push_frames_to_context(frames)
+      frames.each do |frame|
+        context.frames.push(frame)
+      end
+    end
+
+    def instruction_name
+      "getlocal"
+    end
+  end
+end

--- a/lib/yarv/getlocal_wc_0.rb
+++ b/lib/yarv/getlocal_wc_0.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative './getlocal'
 
 module YARV
   # ### Summary
@@ -26,21 +27,15 @@ module YARV
   # # 0006 leave
   # ~~~
   #
-  class GetLocalWC0
-    attr_reader :name, :index
-
+  class GetLocalWC0 < GetLocal
     def initialize(name, index)
-      @name = name
-      @index = index
+      super(name, index, 0)
     end
 
-    def call(context)
-      value = context.current_frame.get_local(index)
-      context.stack.push(value)
-    end
+    private
 
-    def to_s
-      "%-38s %s@%d" % ["getlocal_WC_0", name, index]
+    def instruction_name
+      "getlocal_WC_0"
     end
   end
 end

--- a/lib/yarv/getlocal_wc_1.rb
+++ b/lib/yarv/getlocal_wc_1.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require_relative './getlocal'
+
+module YARV
+  # ### Summary
+  #
+  # `getlocal_WC_1` is a specialized version of the `getlocal` instruction. It
+  # fetches the value of a local variable from the parent frame determined by
+  # the index given as its only argument.
+  #
+  # ### TracePoint
+  #
+  # `getlocal_WC_1` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # value = 5
+  # Proc.new do
+  #   value
+  # end
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,29)> (catch: FALSE)
+  # # local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+  # # [ 1] value@0
+  # # 0000 putobject                              5                         (   1)[Li]
+  # # 0001 setlocal_WC_0                          value@0
+  # # 0003 opt_getinlinecache                     12, <is:0>
+  # # 0006 putobject                              true
+  # # 0008 getconstant                            :Proc
+  # # 0010 opt_setinlinecache                     <is:0>
+  # # 0012 send                                   <calldata!mid:new, argc:0>, block in <main>
+  # # 0015 leave
+  # #
+  # # == disasm: #<ISeq:block in <main>@-e:1 (1,20)-(1,29)> (catch: FALSE)
+  # # 0000 getlocal_WC_1                          value@0                   (   1)[LiBc]
+  # # 0002 leave                                  [Br]
+  # ~~~
+  #
+  class GetLocalWC1 < GetLocal
+    def initialize(name, index)
+      super(name, index, 1)
+    end
+
+    private
+
+    def instruction_name
+      "getlocal_WC_1"
+    end
+  end
+end

--- a/lib/yarv/send.rb
+++ b/lib/yarv/send.rb
@@ -37,13 +37,12 @@ module YARV
     end
 
     def call(context)
-      receiver, *arguments = context.stack.pop(call_data.argc + 1)
-      result =
-        context.call_method(call_data, receiver, arguments) do
-          block_iseq.eval(context)
+      arguments = context.stack.pop(call_data.argc + 1)
+      block_iseq.eval(context) do
+        arguments.each_with_index do |argument, index|
+          context.current_frame.locals[index] = argument
         end
-
-      context.stack.push(result)
+      end
     end
 
     def to_s

--- a/lib/yarv/send.rb
+++ b/lib/yarv/send.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `send`
+  #
+  # ### TracePoint
+  #
+  # `send`
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  #
+  #
+  # ~~~
+  #
+  class Send
+    attr_reader :call_data, :block_iseq
+
+    def initialize(call_data, block_iseq)
+      @call_data = call_data
+      @block_iseq = block_iseq
+    end
+
+    def call(context)
+      receiver, *arguments = context.stack.pop(call_data.argc + 1)
+      result =
+        context.call_method(call_data, receiver, arguments) do
+          block_iseq.eval(context)
+        end
+
+      context.stack.push(result)
+    end
+
+    def pretty_print(q)
+      # q.text(
+      #   "opt_send_without_block <calldata!mid:#{mid}, argc:#{argc}, FCALL|ARGS_SIMPLE>"
+      # )
+    end
+  end
+end

--- a/lib/yarv/send.rb
+++ b/lib/yarv/send.rb
@@ -3,18 +3,30 @@
 module YARV
   # ### Summary
   #
-  # `send`
+  # `send` invokes a method with a block.
   #
   # ### TracePoint
   #
-  # `send`
+  # `send` does not dispatch any events.
   #
   # ### Usage
   #
   # ~~~ruby
+  # "hello".tap { |i| p i }
   #
-  #
-  # ~~~
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,23)> (catch: FALSE)
+  # # 0000 putstring                              "hello"                   (   1)[Li]
+  # # 0002 send                                   <calldata!mid:tap, argc:0>, block in <main>
+  # # 0005 leave
+  # #
+  # # == disasm: #<ISeq:block in <main>@-e:1 (1,12)-(1,23)> (catch: FALSE)
+  # # local table (size: 1, argc: 1 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+  # # [ 1] i@0<Arg>
+  # # 0000 putself                                                          (   1)[LiBc]
+  # # 0001 getlocal_WC_0                          i@0
+  # # 0003 opt_send_without_block                 <calldata!mid:p, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0005 leave                                  [Br]
+  # # ~~~
   #
   class Send
     attr_reader :call_data, :block_iseq
@@ -34,10 +46,8 @@ module YARV
       context.stack.push(result)
     end
 
-    def pretty_print(q)
-      # q.text(
-      #   "opt_send_without_block <calldata!mid:#{mid}, argc:#{argc}, FCALL|ARGS_SIMPLE>"
-      # )
+    def to_s
+      "%-38s %s, block in <main>" % ["send", call_data]
     end
   end
 end

--- a/lib/yarv/setlocal.rb
+++ b/lib/yarv/setlocal.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `setlocal` instruction sets the value of a local variable on the
+  # frame at a given depth below the current frame, determined by the depth
+  # and the index given as its arguments.
+  #
+  # ### TracePoint
+  #
+  # `setlocal` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # value = 2
+  # Proc.new do
+  #   Proc.new do
+  #     value = 5
+  #   end
+  # end
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,46)> (catch: FALSE)
+  # # local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+  # # [ 1] value@0
+  # # 0000 putobject                              2                         (   1)[Li]
+  # # 0002 setlocal_WC_0                          value@0
+  # # 0004 opt_getinlinecache                     13, <is:0>
+  # # 0007 putobject                              true
+  # # 0009 getconstant                            :Proc
+  # # 0011 opt_setinlinecache                     <is:0>
+  # # 0013 send                                   <calldata!mid:new, argc:0>, block in <main>
+  # # 0016 leave
+  # #
+  # # == disasm: #<ISeq:block in <main>@-e:1 (1,20)-(1,46)> (catch: FALSE)
+  # # 0000 opt_getinlinecache                     9, <is:0>                 (   1)[LiBc]
+  # # 0003 putobject                              true
+  # # 0005 getconstant                            :Proc
+  # # 0007 opt_setinlinecache                     <is:0>
+  # # 0009 send                                   <calldata!mid:new, argc:0>, block (2 levels) in <main>
+  # # 0012 leave                                  [Br]
+  # #
+  # # == disasm: #<ISeq:block (2 levels) in <main>@-e:1 (1,31)-(1,44)> (catch: FALSE)
+  # # 0000 putobject                              5                         (   1)[LiBc]
+  # # 0002 dup
+  # # 0003 setlocal                               value@0, 2
+  # # 0006 leave                                  [Br]
+  # ~~~
+  #
+  class SetLocal
+    attr_reader :name, :index, :depth
+
+    def initialize(name, index, depth)
+      @name = name
+      @index = index
+      @depth = depth
+    end
+
+    def call(context)
+      frames = pop_frames_from_context
+
+      value = context.stack.pop
+      context.current_frame.set_local(index, value)
+
+      push_frames_to_context(frames)
+    end
+
+    def to_s
+      "%-38s %s@%d" % [instruction_name, name, index]
+    end
+
+    private
+
+    def pop_frames_from_context
+      depth.times.with_object([]) do |frame, frames|
+        frames << context.frames.pop
+      end
+    end
+
+    def push_frames_to_context(frames)
+      frames.each do |frame|
+        context.frames.push(frame)
+      end
+    end
+
+    def instruction_name
+      "setlocal"
+    end
+  end
+end

--- a/lib/yarv/setlocal_wc_0.rb
+++ b/lib/yarv/setlocal_wc_0.rb
@@ -25,21 +25,15 @@ module YARV
   # # 0005 leave
   # ~~~
   #
-  class SetLocalWC0
-    attr_reader :name, :index
-
+  class SetLocalWC0 < SetLocal
     def initialize(name, index)
-      @name = name
-      @index = index
+      super(name, index, 0)
     end
 
-    def call(context)
-      value = context.stack.pop
-      context.current_frame.set_local(index, value)
-    end
+    private
 
-    def to_s
-      "%-38s %s@%d" % ["setlocal_WC_0", name, index]
+    def instruction_name
+      "setlocal_WC_0"
     end
   end
 end

--- a/lib/yarv/setlocal_wc_1.rb
+++ b/lib/yarv/setlocal_wc_1.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `setlocal_WC_1` is a specialized version of the `setlocal` instruction. It
+  # sets the value of a local variable on the parent frame to the value at the
+  # top of the stack as determined by the index given as its only argument.
+  #
+  # ### TracePoint
+  #
+  # `setlocal_WC_1` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # value = 2
+  # Proc.new do
+  #   value = 5
+  # end
+  #
+  # # == disasm: #<ISeq:<main>@-e:1 (1,0)-(1,33)> (catch: FALSE)
+  # # local table (size: 1, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
+  # # [ 1] value@0
+  # # 0000 putobject                              2                         (   1)[Li]
+  # # 0001 setlocal_WC_0                          value@0
+  # # 0003 opt_getinlinecache                     12, <is:0>
+  # # 0006 putobject                              true
+  # # 0008 getconstant                            :Proc
+  # # 0010 opt_setinlinecache                     <is:0>
+  # # 0012 send                                   <calldata!mid:new, argc:0>, block in <main>
+  # # 0015 leave
+  # #
+  # # == disasm: #<ISeq:block in <main>@-e:1 (1,20)-(1,33)> (catch: FALSE)
+  # # 0000 putobject                              5                         (   1)[LiBc]
+  # # 0002 dup
+  # # 0003 setlocal_WC_1                          value@0
+  # # 0005 leave                                  [Br]
+  # ~~~
+  #
+  class SetLocalWC1 < SetLocal
+    def initialize(name, index)
+      super(name, index, 0)
+    end
+
+    private
+
+    def instruction_name
+      "setlocal_WC_1"
+    end
+  end
+end

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -6,20 +6,20 @@ module YARV
   class SendTest < TestCase
     def test_compile_returns_correct_instructions
       source = <<~SOURCE
-        "hello".tap {}
+        true.tap { |i| p i }
       SOURCE
 
       assert_insns(
-        [PutString, Send, Leave],
+        [PutObject, Send, Leave],
         source
       )
       iseq = YARV.compile(source)
       assert_equal(
-        [PutNil, Leave],
+        [PutSelf, GetLocalWC0, OptSendWithoutBlock, Leave],
         iseq.insns[1].block_iseq.insns.map(&:class)
       )
 
-      assert_stdout("", source)
+      assert_stdout("true\n", source)
     end
   end
 end

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative "test_case"
+
+module YARV
+  class SendTest < TestCase
+    def test_compile_returns_correct_instructions
+      source = <<~SOURCE
+        "hello".tap {}
+      SOURCE
+
+      assert_insns(
+        [PutString, Send, Leave],
+        source
+      )
+      iseq = YARV.compile(source)
+      assert_equal(
+        [PutNil, Leave],
+        iseq.insns[1].block_iseq.insns.map(&:class)
+      )
+
+      assert_stdout("", source)
+    end
+  end
+end

--- a/test/send_test.rb
+++ b/test/send_test.rb
@@ -9,10 +9,7 @@ module YARV
         true.tap { |i| p i }
       SOURCE
 
-      assert_insns(
-        [PutObject, Send, Leave],
-        source
-      )
+      assert_insns([PutObject, Send, Leave], source)
       iseq = YARV.compile(source)
       assert_equal(
         [PutSelf, GetLocalWC0, OptSendWithoutBlock, Leave],


### PR DESCRIPTION
This is a draft PR for a couple of reasons:

1. It's based on the WIP #134 
2. It's not ready for primetime

On point 2, here are some observations:

- `assert_insns` needs to be adjusted to accept input across multiple frames (e.g. via an array of arrays?)
- Method execution needs to be properly implemented, such that locals belonging to frames above the current one are able to be manipulated -- e.g. this will fail:
```rb
assert_stdout("5\n", "value = 0; def bump_value; value = 5; end; bump_value; p value")
```
because `value` is not actually changed.
- Proc calls need to be implemented, too (not to mention lambdas, but we have no `putspecialobject` yet) -- e.g. this will fail:
```rb
assert_stdout("5\n", "value = 0; Proc.new { value = 5 }.call; p value")
```
because the wrong object (`5`, the most recent object added to the `values` stack) is invoked; I think this speaks to a larger issue of how frames/locals are declared and accessed but have not looked deeper just yet.