### PR TITLE
Implement `opt_case_dispatch` for handling case statements

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -287,6 +287,8 @@ module YARV
           @insns << OptAref.new(CallData.new(:[], 1, flag))
         in :opt_aref_with, key, { mid: :[], orig_argc: 1, flag: }
           @insns << OptArefWith.new(key, CallData.new(:[], 1, flag))
+        in :opt_case_dispatch, cdhash, offset
+          @insns << OptCaseDispatch.new(cdhash, offset)
         in :opt_div, { mid: :/, orig_argc: 1, flag: }
           @insns << OptDiv.new(CallData.new(:/, 1, flag))
         in :opt_empty_p, { mid: :empty?, orig_argc: 0, flag: }
@@ -361,6 +363,8 @@ module YARV
           @insns << SetLocalWC0.new(locals[index], index)
         in [:swap]
           @insns << Swap.new
+        in :topn, n
+          # skip for now
         end
       end
     end

--- a/lib/yarv/opt_case_dispatch.rb
+++ b/lib/yarv/opt_case_dispatch.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `opt_case_dispatch` is a branch instruction that moves the control flow for
+  # case statements.
+  #
+  # It has two arguments: the cdhash and an else_offset index. It pops one value off
+  # the stack: a hash key. `opt_case_dispatch` looks up the key in the cdhash
+  # and jumps to the corresponding index value, if there is one.
+  # If there is no value in the cdhash, `opt_case_dispatch` jumps to the else_offset index.
+  #
+  # The cdhash is a Ruby hash used for handling optimized `case` statements.
+  # The keys are the conditions of `when` clauses in the `case` statement,
+  # and the values are the labels to which to jump. This optimization can be
+  # applied only when the keys can be directly compared.
+  #
+  # ### TracePoint
+  #
+  # There is no trace point for `opt_case_dispatch`.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # case 1
+  # when 1
+  #   puts "foo"
+  # else
+  #   puts "bar"
+  # end
+  #
+  # # == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,49)> (catch: FALSE)
+  # # 0000 putobject_INT2FIX_0_                                             (   1)[Li]
+  # # 0001 dup
+  # # 0002 opt_case_dispatch                      <cdhash>, 12
+  # # 0005 putobject_INT2FIX_1_
+  # # 0006 topn                                   1
+  # # 0008 opt_send_without_block                 <calldata!mid:===, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0010 branchif                               19
+  # # 0012 pop
+  # # 0013 putself
+  # # 0014 putstring                              "bar"
+  # # 0016 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0018 leave
+  # # 0019 pop
+  # # 0020 putself
+  # # 0021 putstring                              "foo"
+  # # 0023 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0025 leave
+  # ~~~
+  #
+  class OptCaseDispatch
+    def initialize(cdhash, else_offset)
+      @cdhash = Hash[*cdhash]
+      @else_offset = else_offset
+    end
+
+    def call(context)
+      hash_key = context.stack.pop
+      if (label = cdhash[hash_key])
+        jump_index = context.current_iseq.labels[label]
+        context.program_counter = jump_index
+      else
+        jump_index = context.current_iseq.labels[else_offset]
+        context.program_counter = jump_index
+      end
+    end
+
+    def to_s
+      "%-38s %s %s" %
+        ["opt_case_dispatch", "<cdhash>,", else_offset["label_".length..]]
+    end
+
+    private
+
+    attr_reader :cdhash, :else_offset
+  end
+end

--- a/test/opt_case_dispatch_test.rb
+++ b/test/opt_case_dispatch_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "./test_case"
+
+module YARV
+  class OptCaseDispatchTest < TestCase
+    def test_opt_case_dispatch_jumps_to_correct_branch
+      source_code = "case 1 when 0 then puts 'foo' else puts 'bar' end"
+      assert_stdout("bar\n", source_code)
+    end
+
+    def test_opt_case_dispatch_can_use_cd_hash_to_jump_to_correct_branch
+      source_code = "case 1 when 1 then puts 'foo' else puts 'bar' end"
+      assert_stdout("foo\n", source_code)
+    end
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/kddnewton/yarv/issues/125

Implements `opt_case_dispatch`, which uses either a cdhash to handle matching simple clauses in a case statement, or evaluates and jumps based on an offset.

`opt_case_dispatch` technically relies on `topn`, but the test cases I've provided don't actually execute the `topn` instructions, so the iseq for `topn` in `yarv.rb` no-ops right now.