### PR TITLE
Implement `topn`

### DIFF
--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -375,6 +375,8 @@ module YARV
           @insns << SetLocalWC0.new(locals[index], index)
         in [:swap]
           @insns << Swap.new
+        in :topn, n
+          @insns << TopN.new(n)
         end
       end
     end

--- a/lib/yarv/topn.rb
+++ b/lib/yarv/topn.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `topn` has one argument: `n`. It gets the nth element from the top of the
+  # stack and pushes it on the stack.
+  #
+  # ### TracePoint
+  #
+  # `topn` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # case 3
+  # when 1..5
+  #   puts "foo"
+  # end
+  #
+  # # == disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(1,36)> (catch: FALSE)
+  # # 0000 putobject                              3                         (   1)[Li]
+  # # 0002 putobject                              1..5
+  # # 0004 topn                                   1
+  # # 0006 opt_send_without_block                 <calldata!mid:===, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0008 branchif                               13
+  # # 0010 pop
+  # # 0011 putnil
+  # # 0012 leave
+  # # 0013 pop
+  # # 0014 putself
+  # # 0015 putstring                              "foo"
+  # # 0017 opt_send_without_block                 <calldata!mid:puts, argc:1, FCALL|ARGS_SIMPLE>
+  # # 0019 leave
+  # ~~~
+  #
+  class TopN
+    def initialize(n)
+      @n = n
+    end
+
+    def call(context)
+      value = context.stack[-n - 1]
+      context.stack.push(value)
+    end
+
+    def to_s
+      "%-38s %d" % ["topn", n]
+    end
+
+    private
+
+    attr_reader :n
+  end
+end

--- a/test/topn_test.rb
+++ b/test/topn_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "./test_case"
+
+module YARV
+  class TopNTest < TestCase
+    def test_top_n_gets_nth_element_from_stack
+      source_code = "case 3 when 1..5 then puts 'foo' end"
+      assert_stdout("foo\n", source_code)
+    end
+  end
+end


### PR DESCRIPTION
Closes: https://github.com/kddnewton/yarv/issues/128

Retrieves the nth value from the stack and pushes it back onto the top of the stack. It's not clear to me whether this value should be _moved_ into the topmost position on the stack, or simply retrieved and pushed onto the top. This PR does the latter, but I could see it making more sense for the value to actually be moved so that it doesn't end up in there twice 🤔 