### PR TITLE
Improve disassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ There isn't really a canonical source for documentation for these instructions b
 
 As a part of the documentation effort, this project also aims to provide an emulator of YARV behavior. This will ensure the documentation doesn't get out of date as it will need to reflect actual Ruby semantics. To run the emulator, after cloning the repository, run `exe/yarv <path_to_file>` from the command line.
 
+### Differences to MRI's YARV
+
+We use the indices of instructions in an ISEQ for the PC, where MRI uses the byte offset of instructions, where instructions have varying length.
+
 ## Getting started
 
 To use this project as a CLI, you can execute the `exe/yarv` executable. That functions similarly to the `ruby` executable. You pass it the path to a Ruby file, and it will execute that file.

--- a/bin/doc
+++ b/bin/doc
@@ -8,7 +8,9 @@ require "kramdown"
 require "stringio"
 require "syntax_tree"
 
-filepaths = Dir[File.expand_path("../lib/yarv/insn/*.rb", __dir__)]
+filepaths = Dir[File.expand_path("../lib/yarv/insn/*.rb", __dir__)] \
+  .reject { |filepath| filepath.end_with?("insn/insn.rb") } # Skip the abstract instruction.
+
 markdown = StringIO.new
 
 # For each YARV instruction file, we're going to yank out the comments.

--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -6,11 +6,12 @@ require "syntax_tree"
 require_relative "yarv/call_data"
 require_relative "yarv/execution_context"
 require_relative "yarv/frame"
+require_relative "yarv/insn/insn.rb"
 require_relative "yarv/instruction_sequence"
 require_relative "yarv/main"
 require_relative "yarv/visitor"
 
-# Require all of the files nested under the lib/yarv directory.
+# Require all of the files nested under the lib/yarv/insn directory.
 Dir[File.expand_path("yarv/insn/*.rb", __dir__)].each do |filepath|
   require_relative "yarv/insn/#{File.basename(filepath, ".rb")}"
 end

--- a/lib/yarv/insn/adjuststack.rb
+++ b/lib/yarv/insn/adjuststack.rb
@@ -18,7 +18,7 @@ module YARV
   # x[0]
   # ~~~
   #
-  class AdjustStack
+  class AdjustStack < Insn
     attr_reader :size
 
     def initialize(size)
@@ -37,7 +37,7 @@ module YARV
       { size: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %d" % ["adjuststack", size]
     end
   end

--- a/lib/yarv/insn/anytostring.rb
+++ b/lib/yarv/insn/anytostring.rb
@@ -22,7 +22,7 @@ module YARV
   # "#{5}"
   # ~~~
   #
-  class AnyToString
+  class AnyToString < Insn
     def ==(other)
       other in AnyToString
     end
@@ -33,7 +33,7 @@ module YARV
       context.stack.push(string)
     end
 
-    def to_s
+    def disasm(iseq)
       "anytostring"
     end
   end

--- a/lib/yarv/insn/branchif.rb
+++ b/lib/yarv/insn/branchif.rb
@@ -21,7 +21,7 @@ module YARV
   # puts x
   # ~~~
   #
-  class BranchIf
+  class BranchIf < Insn
     attr_reader :label
 
     def initialize(label)
@@ -45,8 +45,9 @@ module YARV
       { label: }
     end
 
-    def to_s
-      "%-38s %s" % ["branchif", label["label_".length..]]
+    def disasm(iseq)
+      target = iseq ? iseq.labels[label] : "??"
+      "%-38s %s (%s)" % ["branchif", label, target]
     end
   end
 end

--- a/lib/yarv/insn/branchnil.rb
+++ b/lib/yarv/insn/branchnil.rb
@@ -22,7 +22,7 @@ module YARV
   # end
   # ~~~
   #
-  class BranchNil
+  class BranchNil < Insn
     attr_reader :label
 
     def initialize(label)
@@ -46,8 +46,9 @@ module YARV
       { label: }
     end
 
-    def to_s
-      "%-38s %s" % ["branchnil", label["label_".length..]]
+    def disasm(iseq)
+      target = iseq ? iseq.labels[label] : "??"
+      "%-38s %s (%s)" % ["branchnil", label, target]
     end
   end
 end

--- a/lib/yarv/insn/branchunless.rb
+++ b/lib/yarv/insn/branchunless.rb
@@ -21,7 +21,7 @@ module YARV
   # end
   # ~~~
   #
-  class BranchUnless
+  class BranchUnless < Insn
     attr_reader :label
 
     def initialize(label)
@@ -45,8 +45,9 @@ module YARV
       { label: }
     end
 
-    def to_s
-      "%-38s %s" % ["branchunless", label["label_".length..]]
+    def disasm(iseq)
+      target = iseq ? iseq.labels[label] : "??"
+      "%-38s %s (%s)" % ["branchunless", label, target]
     end
   end
 end

--- a/lib/yarv/insn/concatarray.rb
+++ b/lib/yarv/insn/concatarray.rb
@@ -19,7 +19,7 @@ module YARV
   # [1, *2]
   # ~~~
   #
-  class ConcatArray
+  class ConcatArray < Insn
     def ==(other)
       other in ConcatArray
     end
@@ -32,7 +32,7 @@ module YARV
       context.stack.push(coerced_left)
     end
 
-    def to_s
+    def disasm(iseq)
       "concatarray"
     end
 

--- a/lib/yarv/insn/concatstrings.rb
+++ b/lib/yarv/insn/concatstrings.rb
@@ -19,7 +19,7 @@ module YARV
   # "#{5}"
   # ~~~
   #
-  class ConcatStrings
+  class ConcatStrings < Insn
     attr_reader :size
 
     def initialize(size)
@@ -39,7 +39,7 @@ module YARV
       { size: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["concatstrings", size]
     end
   end

--- a/lib/yarv/insn/defined.rb
+++ b/lib/yarv/insn/defined.rb
@@ -16,7 +16,7 @@ module YARV
   # defined?(x)
   # ~~~
   #
-  class Defined
+  class Defined < Insn
     DEFINED_TYPE = %i[
       DEFINED_NOT_DEFINED
       DEFINED_NIL
@@ -57,7 +57,7 @@ module YARV
       context.stack.push(vm_defined?(context, predicate) ? value : nil)
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s, %s" % ["defined", type, object.inspect, value.inspect]
     end
 

--- a/lib/yarv/insn/definemethod.rb
+++ b/lib/yarv/insn/definemethod.rb
@@ -17,7 +17,7 @@ module YARV
   # def value = "value"
   # ~~~
   #
-  class DefineMethod
+  class DefineMethod < Insn
     attr_reader :name, :iseq
 
     def initialize(name, iseq)
@@ -37,7 +37,7 @@ module YARV
       { name:, iseq: }
     end
 
-    def to_s
+    def disasm(containing_iseq)
       "%-38s %s, %s" % ["definemethod", name.inspect, iseq.name]
     end
   end

--- a/lib/yarv/insn/dup.rb
+++ b/lib/yarv/insn/dup.rb
@@ -15,7 +15,7 @@ module YARV
   # $global = 5
   # ~~~
   #
-  class Dup
+  class Dup < Insn
     def ==(other)
       other in Dup
     end
@@ -26,7 +26,7 @@ module YARV
       context.stack.push(value)
     end
 
-    def to_s
+    def disasm(iseq)
       "dup"
     end
   end

--- a/lib/yarv/insn/dup_hash.rb
+++ b/lib/yarv/insn/dup_hash.rb
@@ -15,7 +15,7 @@ module YARV
   # { a: 1 }
   # ~~~
   #
-  class DupHash
+  class DupHash < Insn
     attr_reader :value
 
     def initialize(value)
@@ -34,7 +34,7 @@ module YARV
       { value: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["duphash", value.inspect]
     end
   end

--- a/lib/yarv/insn/duparray.rb
+++ b/lib/yarv/insn/duparray.rb
@@ -15,7 +15,7 @@ module YARV
   # [true]
   # ~~~
   #
-  class DupArray
+  class DupArray < Insn
     attr_reader :value
 
     def initialize(value)
@@ -34,7 +34,7 @@ module YARV
       { value: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["duparray", value.inspect]
     end
   end

--- a/lib/yarv/insn/dupn.rb
+++ b/lib/yarv/insn/dupn.rb
@@ -15,7 +15,7 @@ module YARV
   # Object::X ||= true
   # ~~~
   #
-  class DupN
+  class DupN < Insn
     attr_reader :offset
 
     def initialize(offset)
@@ -34,7 +34,7 @@ module YARV
       { offset: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %d" % ["dupn", offset]
     end
   end

--- a/lib/yarv/insn/getconstant.rb
+++ b/lib/yarv/insn/getconstant.rb
@@ -16,7 +16,7 @@ module YARV
   # Constant
   # ~~~
   #
-  class GetConstant
+  class GetConstant < Insn
     attr_reader :name
 
     def initialize(name)
@@ -43,7 +43,7 @@ module YARV
       { name: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["getconstant", name.inspect]
     end
   end

--- a/lib/yarv/insn/getglobal.rb
+++ b/lib/yarv/insn/getglobal.rb
@@ -15,7 +15,7 @@ module YARV
   # $$
   # ~~~
   #
-  class GetGlobal
+  class GetGlobal < Insn
     attr_reader :name
 
     def initialize(name)
@@ -42,7 +42,7 @@ module YARV
       { name: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["getglobal", name.inspect]
     end
   end

--- a/lib/yarv/insn/getlocal.rb
+++ b/lib/yarv/insn/getlocal.rb
@@ -19,7 +19,7 @@ module YARV
   # tap { tap { value } }
   # ~~~
   #
-  class GetLocal
+  class GetLocal < Insn
     attr_reader :name, :index, :level
 
     def initialize(name, index, level)
@@ -41,7 +41,7 @@ module YARV
       { name:, index:, level: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s@%d, %d" % ["getlocal", name, index, level]
     end
   end

--- a/lib/yarv/insn/getlocal_wc_0.rb
+++ b/lib/yarv/insn/getlocal_wc_0.rb
@@ -18,7 +18,7 @@ module YARV
   # value
   # ~~~
   #
-  class GetLocalWC0
+  class GetLocalWC0 < Insn
     attr_reader :name, :index
 
     def initialize(name, index)
@@ -39,7 +39,7 @@ module YARV
       { name:, index: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s@%d" % ["getlocal_WC_0", name, index]
     end
   end

--- a/lib/yarv/insn/getlocal_wc_1.rb
+++ b/lib/yarv/insn/getlocal_wc_1.rb
@@ -18,7 +18,7 @@ module YARV
   # self.then { value }
   # ~~~
   #
-  class GetLocalWC1
+  class GetLocalWC1 < Insn
     attr_reader :name, :index
 
     def initialize(name, index)
@@ -39,7 +39,7 @@ module YARV
       { name:, index: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s@%d" % ["getlocal_WC_1", name, index]
     end
   end

--- a/lib/yarv/insn/insn.rb
+++ b/lib/yarv/insn/insn.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module YARV
+  # Abstract base instruction.
+  class Insn
+    def to_s
+      disasm(nil)
+    end
+  end
+end

--- a/lib/yarv/insn/intern.rb
+++ b/lib/yarv/insn/intern.rb
@@ -15,7 +15,7 @@ module YARV
   # :"#{"foo"}"
   # ~~~
   #
-  class Intern
+  class Intern < Insn
     def ==(other)
       other in Intern
     end
@@ -25,7 +25,7 @@ module YARV
       context.stack.push(string.to_sym)
     end
 
-    def to_s
+    def disasm(iseq)
       "intern"
     end
   end

--- a/lib/yarv/insn/invokeblock.rb
+++ b/lib/yarv/insn/invokeblock.rb
@@ -23,7 +23,7 @@ module YARV
   # # 0002 leave                                  [Re]
   # # ~~~
   #
-  class InvokeBlock
+  class InvokeBlock < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -45,7 +45,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["invokeblock", call_data]
     end
   end

--- a/lib/yarv/insn/jump.rb
+++ b/lib/yarv/insn/jump.rb
@@ -21,7 +21,7 @@ module YARV
   # end
   # ~~~
   #
-  class Jump
+  class Jump < Insn
     attr_reader :label
 
     def initialize(label)
@@ -41,7 +41,7 @@ module YARV
       { label: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["jump", label["label_".length..]]
     end
   end

--- a/lib/yarv/insn/leave.rb
+++ b/lib/yarv/insn/leave.rb
@@ -15,7 +15,7 @@ module YARV
   # ;;
   # ~~~
   #
-  class Leave
+  class Leave < Insn
     def ==(other)
       other in Leave
     end
@@ -24,7 +24,7 @@ module YARV
       # skip for now
     end
 
-    def to_s
+    def disasm(iseq)
       "leave"
     end
   end

--- a/lib/yarv/insn/newarray.rb
+++ b/lib/yarv/insn/newarray.rb
@@ -15,7 +15,7 @@ module YARV
   # ["string"]
   # ~~~
   #
-  class NewArray
+  class NewArray < Insn
     attr_reader :size
 
     def initialize(size)
@@ -35,7 +35,7 @@ module YARV
       { size: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["newarray", size]
     end
   end

--- a/lib/yarv/insn/newhash.rb
+++ b/lib/yarv/insn/newhash.rb
@@ -18,7 +18,7 @@ module YARV
   # end
   # ~~~
   #
-  class NewHash
+  class NewHash < Insn
     attr_reader :size
 
     def initialize(size)
@@ -38,7 +38,7 @@ module YARV
       { size: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["newhash", size]
     end
   end

--- a/lib/yarv/insn/newrange.rb
+++ b/lib/yarv/insn/newrange.rb
@@ -18,7 +18,7 @@ module YARV
   # p (x..y), (x...y)
   # ~~~
   #
-  class NewRange
+  class NewRange < Insn
     attr_reader :exclude_end
 
     def initialize(exclude_end)
@@ -42,7 +42,7 @@ module YARV
       { exclude_end: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %d" % ["newrange", exclude_end]
     end
   end

--- a/lib/yarv/insn/nop.rb
+++ b/lib/yarv/insn/nop.rb
@@ -16,7 +16,7 @@ module YARV
   # raise rescue true
   # ~~~
   #
-  class Nop
+  class Nop < Insn
     def ==(other)
       other in Nop
     end
@@ -24,7 +24,7 @@ module YARV
     def call(context)
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s" % ["nop"]
     end
   end

--- a/lib/yarv/insn/objtostring.rb
+++ b/lib/yarv/insn/objtostring.rb
@@ -19,7 +19,7 @@ module YARV
   # "#{5}"
   # ~~~
   #
-  class ObjToString
+  class ObjToString < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -41,7 +41,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["objtostring", call_data]
     end
   end

--- a/lib/yarv/insn/opt_and.rb
+++ b/lib/yarv/insn/opt_and.rb
@@ -17,7 +17,7 @@ module YARV
   # 2 & 3
   # ~~~
   #
-  class OptAnd
+  class OptAnd < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_and", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_aref.rb
+++ b/lib/yarv/insn/opt_aref.rb
@@ -17,7 +17,7 @@ module YARV
   # 7[2]
   # ~~~
   #
-  class OptAref
+  class OptAref < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_aref", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_aref_with.rb
+++ b/lib/yarv/insn/opt_aref_with.rb
@@ -17,7 +17,7 @@ module YARV
   # { 'test' => true }['test']
   # ~~~
   #
-  class OptArefWith
+  class OptArefWith < Insn
     attr_reader :key, :call_data
 
     def initialize(key, call_data)
@@ -40,7 +40,7 @@ module YARV
       { key: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s" % ["opt_aref_with", key, call_data]
     end
   end

--- a/lib/yarv/insn/opt_aset.rb
+++ b/lib/yarv/insn/opt_aset.rb
@@ -15,7 +15,7 @@ module YARV
   # {}[:key] = value
   # ~~~
   #
-  class OptAset
+  class OptAset < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_aset", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_aset_with.rb
+++ b/lib/yarv/insn/opt_aset_with.rb
@@ -16,7 +16,7 @@ module YARV
   # {}["key"] = value
   # ~~~
   #
-  class OptAsetWith
+  class OptAsetWith < Insn
     attr_reader :key, :call_data
 
     def initialize(key, call_data)
@@ -39,7 +39,7 @@ module YARV
       { key:, call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s" % ["opt_aset_with", key.inspect, call_data]
     end
   end

--- a/lib/yarv/insn/opt_case_dispatch.rb
+++ b/lib/yarv/insn/opt_case_dispatch.rb
@@ -50,7 +50,7 @@ module YARV
   # # 0025 leave
   # ~~~
   #
-  class OptCaseDispatch
+  class OptCaseDispatch < Insn
     attr_reader :cdhash, :else_offset
 
     def initialize(cdhash, else_offset)
@@ -77,7 +77,7 @@ module YARV
       { cdhash:, else_offset: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s %s" %
         ["opt_case_dispatch", "<cdhash>,", else_offset["label_".length..]]
     end

--- a/lib/yarv/insn/opt_div.rb
+++ b/lib/yarv/insn/opt_div.rb
@@ -17,7 +17,7 @@ module YARV
   # 2 / 3
   # ~~~
   #
-  class OptDiv
+  class OptDiv < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_div", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_empty_p.rb
+++ b/lib/yarv/insn/opt_empty_p.rb
@@ -17,7 +17,7 @@ module YARV
   # "".empty?
   # ~~~
   #
-  class OptEmptyP
+  class OptEmptyP < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_empty_p", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_eq.rb
+++ b/lib/yarv/insn/opt_eq.rb
@@ -15,7 +15,7 @@ module YARV
   # 2 == 2
   # ~~~
   #
-  class OptEq
+  class OptEq < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_eq", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_ge.rb
+++ b/lib/yarv/insn/opt_ge.rb
@@ -15,7 +15,7 @@ module YARV
   # 4 >= 3
   # ~~~
   #
-  class OptGe
+  class OptGe < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_ge", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_getinlinecache.rb
+++ b/lib/yarv/insn/opt_getinlinecache.rb
@@ -17,7 +17,7 @@ module YARV
   # Constant
   # ~~~
   #
-  class OptGetInlineCache
+  class OptGetInlineCache < Insn
     attr_reader :label, :cache
 
     def initialize(label, cache)
@@ -41,7 +41,7 @@ module YARV
       { label:, cache: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, <is:%d>" %
         ["opt_getinlinecache", label["label_".length..], cache]
     end

--- a/lib/yarv/insn/opt_gt.rb
+++ b/lib/yarv/insn/opt_gt.rb
@@ -15,7 +15,7 @@ module YARV
   # 4 > 3
   # ~~~
   #
-  class OptGt
+  class OptGt < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_gt", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_le.rb
+++ b/lib/yarv/insn/opt_le.rb
@@ -15,7 +15,7 @@ module YARV
   # 3 <= 4
   # ~~~
   #
-  class OptLe
+  class OptLe < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_le", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_length.rb
+++ b/lib/yarv/insn/opt_length.rb
@@ -17,7 +17,7 @@ module YARV
   # "".length
   # ~~~
   #
-  class OptLength
+  class OptLength < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_length", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_lt.rb
+++ b/lib/yarv/insn/opt_lt.rb
@@ -15,7 +15,7 @@ module YARV
   # 3 < 4
   # ~~~
   #
-  class OptLt
+  class OptLt < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_lt", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_ltlt.rb
+++ b/lib/yarv/insn/opt_ltlt.rb
@@ -21,7 +21,7 @@ module YARV
   # # 0006 leave
   # ~~~
   #
-  class OptLtLt
+  class OptLtLt < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -43,7 +43,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_ltlt", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_minus.rb
+++ b/lib/yarv/insn/opt_minus.rb
@@ -17,7 +17,7 @@ module YARV
   # 3 - 2
   # ~~~
   #
-  class OptMinus
+  class OptMinus < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_minus", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_mod.rb
+++ b/lib/yarv/insn/opt_mod.rb
@@ -15,7 +15,7 @@ module YARV
   # 4 % 2
   # ~~~
   #
-  class OptMod
+  class OptMod < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_mod", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_mult.rb
+++ b/lib/yarv/insn/opt_mult.rb
@@ -17,7 +17,7 @@ module YARV
   # 3 * 2
   # ~~~
   #
-  class OptMult
+  class OptMult < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_mult", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_neq.rb
+++ b/lib/yarv/insn/opt_neq.rb
@@ -19,7 +19,7 @@ module YARV
   # 2 != 2
   # ~~~
   #
-  class OptNeq
+  class OptNeq < Insn
     attr_reader :cd_neq, :cd_eq
 
     def initialize(cd_eq, cd_neq)
@@ -42,7 +42,7 @@ module YARV
       { cd_eq:, cd_neq: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s%s" % ["opt_neq", cd_eq, cd_neq, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_newarray_max.rb
+++ b/lib/yarv/insn/opt_newarray_max.rb
@@ -14,7 +14,7 @@ module YARV
   # [1, x = 2].max
   # ~~~
   #
-  class OptNewArrayMax
+  class OptNewArrayMax < Insn
     attr_reader :size
 
     def initialize(size)
@@ -38,7 +38,7 @@ module YARV
       { size: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %d" % ["opt_newarray_max", size]
     end
   end

--- a/lib/yarv/insn/opt_newarray_min.rb
+++ b/lib/yarv/insn/opt_newarray_min.rb
@@ -14,7 +14,7 @@ module YARV
   # [1, x = 2].min
   # ~~~
   #
-  class OptNewArrayMin
+  class OptNewArrayMin < Insn
     attr_reader :size
 
     def initialize(size)
@@ -38,7 +38,7 @@ module YARV
       { size: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %d" % ["opt_newarray_min", size]
     end
   end

--- a/lib/yarv/insn/opt_nil_p.rb
+++ b/lib/yarv/insn/opt_nil_p.rb
@@ -17,7 +17,7 @@ module YARV
   # "".nil?
   # ~~~
   #
-  class OptNilP
+  class OptNilP < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_nil_p", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_not.rb
+++ b/lib/yarv/insn/opt_not.rb
@@ -15,7 +15,7 @@ module YARV
   # !true
   # ~~~
   #
-  class OptNot
+  class OptNot < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -37,7 +37,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_not", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_or.rb
+++ b/lib/yarv/insn/opt_or.rb
@@ -17,7 +17,7 @@ module YARV
   # 2 | 3
   # ~~~
   #
-  class OptOr
+  class OptOr < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_or", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_plus.rb
+++ b/lib/yarv/insn/opt_plus.rb
@@ -17,7 +17,7 @@ module YARV
   # 2 + 3
   # ~~~
   #
-  class OptPlus
+  class OptPlus < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_plus", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_regexpmatch2.rb
+++ b/lib/yarv/insn/opt_regexpmatch2.rb
@@ -16,7 +16,7 @@ module YARV
   # /a/ =~ "a"
   # ~~~
   #
-  class OptRegexpMatch2
+  class OptRegexpMatch2 < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -38,7 +38,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_regexpmatch2", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_send_without_block.rb
+++ b/lib/yarv/insn/opt_send_without_block.rb
@@ -16,7 +16,7 @@ module YARV
   # puts "Hello, world!"
   # ~~~
   #
-  class OptSendWithoutBlock
+  class OptSendWithoutBlock < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -38,7 +38,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["opt_send_without_block", call_data]
     end
   end

--- a/lib/yarv/insn/opt_setinlinecache.rb
+++ b/lib/yarv/insn/opt_setinlinecache.rb
@@ -17,7 +17,7 @@ module YARV
   # Constant
   # ~~~
   #
-  class OptSetInlineCache
+  class OptSetInlineCache < Insn
     attr_reader :cache
 
     def initialize(cache)
@@ -37,7 +37,7 @@ module YARV
       { cache: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s <is:%d>" % ["opt_setinlinecache", cache]
     end
   end

--- a/lib/yarv/insn/opt_size.rb
+++ b/lib/yarv/insn/opt_size.rb
@@ -17,7 +17,7 @@ module YARV
   # "".size
   # ~~~
   #
-  class OptSize
+  class OptSize < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_size", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/opt_str_freeze.rb
+++ b/lib/yarv/insn/opt_str_freeze.rb
@@ -16,7 +16,7 @@ module YARV
   # "hello".freeze
   # ~~~
   #
-  class OptStrFreeze
+  class OptStrFreeze < Insn
     attr_reader :value, :call_data
 
     def initialize(value, call_data)
@@ -37,7 +37,7 @@ module YARV
       { value:, call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s" % ["opt_str_freeze", value.inspect, call_data]
     end
   end

--- a/lib/yarv/insn/opt_str_uminus.rb
+++ b/lib/yarv/insn/opt_str_uminus.rb
@@ -16,7 +16,7 @@ module YARV
   # -"string"
   # ~~~
   #
-  class OptStrUMinus
+  class OptStrUMinus < Insn
     attr_reader :value, :call_data
 
     def initialize(value, call_data)
@@ -39,7 +39,7 @@ module YARV
       { value:, call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s" % ["opt_str_uminus", value.inspect, call_data]
     end
   end

--- a/lib/yarv/insn/opt_succ.rb
+++ b/lib/yarv/insn/opt_succ.rb
@@ -17,7 +17,7 @@ module YARV
   # "".succ
   # ~~~
   #
-  class OptSucc
+  class OptSucc < Insn
     attr_reader :call_data
 
     def initialize(call_data)
@@ -39,7 +39,7 @@ module YARV
       { call_data: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s%s" % ["opt_succ", call_data, "[CcCr]"]
     end
   end

--- a/lib/yarv/insn/pop.rb
+++ b/lib/yarv/insn/pop.rb
@@ -15,7 +15,7 @@ module YARV
   # a ||= 2
   # ~~~
   #
-  class Pop
+  class Pop < Insn
     def ==(other)
       other in Pop
     end
@@ -24,7 +24,7 @@ module YARV
       context.stack.pop
     end
 
-    def to_s
+    def disasm(iseq)
       "pop"
     end
   end

--- a/lib/yarv/insn/putnil.rb
+++ b/lib/yarv/insn/putnil.rb
@@ -15,7 +15,7 @@ module YARV
   # nil
   # ~~~
   #
-  class PutNil
+  class PutNil < Insn
     def ==(other)
       other in PutNil
     end
@@ -24,7 +24,7 @@ module YARV
       context.stack.push(nil)
     end
 
-    def to_s
+    def disasm(iseq)
       "putnil"
     end
   end

--- a/lib/yarv/insn/putobject.rb
+++ b/lib/yarv/insn/putobject.rb
@@ -15,7 +15,7 @@ module YARV
   # 5
   # ~~~
   #
-  class PutObject
+  class PutObject < Insn
     attr_reader :object
 
     def initialize(object)
@@ -34,7 +34,7 @@ module YARV
       { object: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["putobject", object.inspect]
     end
   end

--- a/lib/yarv/insn/putobject_int2fix_0.rb
+++ b/lib/yarv/insn/putobject_int2fix_0.rb
@@ -17,7 +17,7 @@ module YARV
   # 0
   # ~~~
   #
-  class PutObjectInt2Fix0
+  class PutObjectInt2Fix0 < Insn
     def ==(other)
       other in PutObjectInt2Fix0
     end
@@ -26,7 +26,7 @@ module YARV
       context.stack.push(0)
     end
 
-    def to_s
+    def disasm(iseq)
       "putobject_INT2FIX_0_"
     end
   end

--- a/lib/yarv/insn/putobject_int2fix_1.rb
+++ b/lib/yarv/insn/putobject_int2fix_1.rb
@@ -17,7 +17,7 @@ module YARV
   # 1
   # ~~~
   #
-  class PutObjectInt2Fix1
+  class PutObjectInt2Fix1 < Insn
     def ==(other)
       other in PutObjectInt2Fix1
     end
@@ -26,7 +26,7 @@ module YARV
       context.stack.push(1)
     end
 
-    def to_s
+    def disasm(iseq)
       "putobject_INT2FIX_1_"
     end
   end

--- a/lib/yarv/insn/putself.rb
+++ b/lib/yarv/insn/putself.rb
@@ -15,7 +15,7 @@ module YARV
   # puts "Hello, world!"
   # ~~~
   #
-  class PutSelf
+  class PutSelf < Insn
     attr_reader :object
 
     def initialize(object)
@@ -34,7 +34,7 @@ module YARV
       { object: }
     end
 
-    def to_s
+    def disasm(iseq)
       "putself"
     end
   end

--- a/lib/yarv/insn/putstring.rb
+++ b/lib/yarv/insn/putstring.rb
@@ -15,7 +15,7 @@ module YARV
   # "foo"
   # ~~~
   #
-  class PutString
+  class PutString < Insn
     attr_reader :string
 
     def initialize(string)
@@ -34,7 +34,7 @@ module YARV
       { string: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["putstring", string.inspect]
     end
   end

--- a/lib/yarv/insn/send.rb
+++ b/lib/yarv/insn/send.rb
@@ -28,7 +28,7 @@ module YARV
   # # 0005 leave                                  [Br]
   # # ~~~
   #
-  class Send
+  class Send < Insn
     attr_reader :call_data, :block_iseq
 
     def initialize(call_data, block_iseq)
@@ -62,7 +62,7 @@ module YARV
       { call_data:, block_iseq: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s" % ["send", call_data, block_iseq.name]
     end
   end

--- a/lib/yarv/insn/setglobal.rb
+++ b/lib/yarv/insn/setglobal.rb
@@ -15,7 +15,7 @@ module YARV
   # $global = 5
   # ~~~
   #
-  class SetGlobal
+  class SetGlobal < Insn
     attr_reader :name
 
     def initialize(name)
@@ -40,7 +40,7 @@ module YARV
       { name: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["setglobal", name.inspect]
     end
   end

--- a/lib/yarv/insn/setlocal.rb
+++ b/lib/yarv/insn/setlocal.rb
@@ -19,7 +19,7 @@ module YARV
   # tap { tap { value = 10 } }
   # ~~~
   #
-  class SetLocal
+  class SetLocal < Insn
     attr_reader :name, :index, :level
 
     def initialize(name, index, level)
@@ -41,7 +41,7 @@ module YARV
       { name:, index:, level: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s@%d, %d" % ["setlocal", name, index, level]
     end
   end

--- a/lib/yarv/insn/setlocal_wc_0.rb
+++ b/lib/yarv/insn/setlocal_wc_0.rb
@@ -17,7 +17,7 @@ module YARV
   # value = 5
   # ~~~
   #
-  class SetLocalWC0
+  class SetLocalWC0 < Insn
     attr_reader :name, :index
 
     def initialize(name, index)
@@ -34,7 +34,7 @@ module YARV
       context.current_frame.set_local(index, value)
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s@%d" % ["setlocal_WC_0", name, index]
     end
   end

--- a/lib/yarv/insn/setlocal_wc_1.rb
+++ b/lib/yarv/insn/setlocal_wc_1.rb
@@ -18,7 +18,7 @@ module YARV
   # self.then { value = 10 }
   # ~~~
   #
-  class SetLocalWC1
+  class SetLocalWC1 < Insn
     attr_reader :name, :index
 
     def initialize(name, index)
@@ -35,7 +35,7 @@ module YARV
       context.parent_frame.set_local(index, value)
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s@%d" % ["setlocal_WC_1", name, index]
     end
   end

--- a/lib/yarv/insn/setn.rb
+++ b/lib/yarv/insn/setn.rb
@@ -13,7 +13,7 @@ module YARV
   # {}[:key] = 'val'
   # ~~~
   #
-  class SetN
+  class SetN < Insn
     attr_reader :index
 
     def initialize(index)
@@ -32,7 +32,7 @@ module YARV
       { index: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s" % ["setn", index]
     end
   end

--- a/lib/yarv/insn/swap.rb
+++ b/lib/yarv/insn/swap.rb
@@ -15,7 +15,7 @@ module YARV
   # !!defined?([[]])
   # ~~~
   #
-  class Swap
+  class Swap < Insn
     def ==(other)
       other in Swap
     end
@@ -26,7 +26,7 @@ module YARV
       context.stack.push(left)
     end
 
-    def to_s
+    def disasm(iseq)
       "swap"
     end
   end

--- a/lib/yarv/insn/topn.rb
+++ b/lib/yarv/insn/topn.rb
@@ -34,7 +34,7 @@ module YARV
   # # 0019 leave
   # ~~~
   #
-  class TopN
+  class TopN < Insn
     attr_reader :n
 
     def initialize(n)
@@ -54,7 +54,7 @@ module YARV
       { n: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %d" % ["topn", n]
     end
   end

--- a/lib/yarv/insn/toregexp.rb
+++ b/lib/yarv/insn/toregexp.rb
@@ -27,7 +27,7 @@ module YARV
   # # 0011 leave
   # ~~~
   #
-  class ToRegexp
+  class ToRegexp < Insn
     attr_reader :opts, :cnt
 
     def initialize(opts, cnt)
@@ -48,7 +48,7 @@ module YARV
       { opts:, cnt: }
     end
 
-    def to_s
+    def disasm(iseq)
       "%-38s %s, %s" % ["toregexp", opts, cnt]
     end
   end

--- a/lib/yarv/instruction_sequence.rb
+++ b/lib/yarv/instruction_sequence.rb
@@ -165,9 +165,7 @@ module YARV
           in [:intern]
             compiled << Intern.new
           in :invokeblock, { mid: nil, orig_argc:, flag: }
-            compiled << InvokeBlock.new(
-              CallData.new(nil, orig_argc, flag)
-            )
+            compiled << InvokeBlock.new(CallData.new(nil, orig_argc, flag))
           in :invokesuper, { mid: nil, orig_argc:, flag: }, block_iseq
             block_iseq = compile(selfo, block_iseq, compiled) if block_iseq
             compiled << UnimplementedInstruction.new(
@@ -377,8 +375,10 @@ module YARV
       end
 
       child_iseqs = []
-      insns.each do |insn|
-        output.puts("#{prefix}0000 #{insn}")
+      insns.each_with_index do |insn, insn_pc|
+        output.puts(
+          "#{prefix}#{insn_pc.to_s.rjust(4, "0")} #{insn.disasm(self)}"
+        )
 
         case insn
         when DefineMethod

--- a/test/disasm_test.rb
+++ b/test/disasm_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module YARV
+  class DisasmTest < Test::Unit::TestCase
+    def test_binary_plus
+      assert_disasm(<<~DISASM, "2 + 3")
+        == disasm #<ISeq:<compiled>> (catch: FALSE)
+        0000 putobject                              2
+        0001 putobject                              3
+        0002 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr]
+        0003 leave
+      DISASM
+    end
+
+    def test_branch_plus
+      assert_disasm(<<~DISASM, "foo ? 1 : 2")
+        == disasm #<ISeq:<compiled>> (catch: FALSE)
+        0000 putself
+        0001 opt_send_without_block                 <calldata!mid:foo, argc:0, FCALL|VCALL|ARGS_SIMPLE>
+        0002 branchunless                           label_7 (5)
+        0003 putobject_INT2FIX_1_
+        0004 leave
+        0005 putobject                              2
+        0006 leave
+      DISASM
+    end
+
+    private
+
+    def assert_disasm(expected, source)
+      assert_equal(expected, YARV.compile(source).disasm)
+    end
+  end
+end


### PR DESCRIPTION
With correct PCs, a note about their format, more information on labels as targets, and tests.

Before:

```
== disasm #<ISeq:foo> (catch: FALSE)
0000 getlocal_WC_0                          a@0
0000 getlocal_WC_0                          b@1
0000 opt_ge                                 <calldata!mid:>=, argc:1, ARGS_SIMPLE>[CcCr]
0000 branchunless                           11
0000 getlocal_WC_0                          a@0
0000 leave
0000 getlocal_WC_0                          b@1
0000 leave
```

After:

```== disasm #<ISeq:foo> (catch: FALSE)
0000 getlocal_WC_0                          a@0
0001 getlocal_WC_0                          b@1
0002 opt_ge                                 <calldata!mid:>=, argc:1, ARGS_SIMPLE>[CcCr]
0003 branchunless                           label_11 (6)
0004 getlocal_WC_0                          a@0
0005 leave
0006 getlocal_WC_0                          b@1
0007 leave
```

Note that before instruction addresses were broken, and the target of the `branchunless` was unintelligible.