### PR TITLE
Implement a basic DFG

### DIFF
--- a/exe/yarv
+++ b/exe/yarv
@@ -7,6 +7,7 @@ require "yarv"
 sources = []
 dump_insns = false
 dump_cfg = false
+dump_dfg = false
 execute = true
 
 until ARGV.empty?
@@ -23,6 +24,9 @@ until ARGV.empty?
     when "--dump=cfg"
       dump_cfg = true
       execute = false
+    when "--dump=dfg"
+      dump_dfg = true
+      execute = false
     else
       raise "Unknown argument #{arg}"
     end
@@ -38,10 +42,15 @@ sources.each do |source, file, path|
     puts compiled.disasm
   end
 
-  if dump_cfg
+  if dump_cfg || dump_dfg
     compiled.all_iseqs.each do |iseq|
       cfg = YARV::CFG.new(iseq)
-      puts cfg.disasm
+      puts cfg.disasm if dump_cfg
+
+      if dump_dfg
+        dfg = YARV::DFG.new(cfg)
+        puts dfg.disasm if dump_dfg
+      end
     end
   end
 

--- a/lib/yarv.rb
+++ b/lib/yarv.rb
@@ -10,6 +10,7 @@ require_relative "yarv/frame"
 require_relative "yarv/instruction"
 require_relative "yarv/instruction_sequence"
 require_relative "yarv/cfg"
+require_relative "yarv/dfg"
 require_relative "yarv/main"
 require_relative "yarv/visitor"
 

--- a/lib/yarv/dfg.rb
+++ b/lib/yarv/dfg.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+module YARV
+  # Constructs a data-flow-graph, or DFG, of a YARV instruction sequence, via
+  # a CFG. We use basic-blog-arguments. Dataflow is discovered locally and then
+  # globally. The graph only considers dataflow through the stack - local
+  # variables anre objects are considered fully escaped in this analysis.
+  class DFG
+    attr_reader :cfg
+    attr_reader :insn_flow
+    attr_reader :block_flow
+
+    def initialize(cfg)
+      @cfg = cfg
+      @insn_flow = {}
+
+      if cfg.iseq.throw_handlers.any?
+        raise "throw handlers not supported in DFG yet"
+      end
+
+      # Create a side data structure to encode dataflow between instructions.
+      @insn_flow = {}
+      cfg.iseq.insns.each_with_index do |insn, insn_pc|
+        insn_flow[insn_pc] = Dataflow.new
+      end
+
+      # Create a side data structure to encode dataflow between basic blocks.
+      @block_flow = {}
+      cfg.blocks.each { |block| @block_flow[block.start] = Dataflow.new }
+
+      # Discover the dataflow.
+      local_flow
+      global_flow
+      verify_flow
+    end
+
+    # Graph dataflow within basic blocks.
+    def local_flow
+      # Using an abstract stack, connect from consumers to producers.
+      cfg.blocks.each do |block|
+        block_dataflow = block_flow[block.start]
+
+        stack = []
+        stack_initial_depth = 0
+
+        # Go through each instruction in the block...
+        block
+          .start
+          .upto(block.start + block.length - 1) do |insn_pc|
+            insn = cfg.iseq.insns[insn_pc]
+            insn_dataflow = insn_flow[insn_pc]
+
+            # For every value the instruction pops off the stack...
+            insn.reads.times do
+              # Was the value it pops off from another basic block?
+              if stack.empty?
+                # Thi is a basic block argument.
+                name = :"in_#{stack_initial_depth}"
+                insn_dataflow.in << name
+                block_dataflow.in << name
+                stack_initial_depth += 1
+              else
+                # Connect this consumer to the producer of the value.
+                insn_dataflow.in << stack.pop
+              end
+            end
+
+            # Record on our abstract stack that this instruction pushed
+            # this value onto the stack.
+            insn.writes.times { stack.push insn_pc }
+          end
+
+        # Values that are left on the stack after going through all
+        # instructions are arguments to the basic block that we jump to.
+        stack.reverse.each_with_index do |producer, n|
+          block_dataflow.out << producer
+          producer_dataflow = insn_flow[producer]
+          producer_dataflow.out << :"out_#{n}"
+        end
+      end
+
+      # Go backwards and connect from producers to consumers.
+      cfg.iseq.insns.each_with_index do |insn, insn_pc|
+        insn_dataflow = insn_flow[insn_pc]
+        # For every instruction that produced a value used in this
+        # instruction...
+        insn_dataflow.in.each do |producer|
+          # If it's actually another instruction and not a basic block
+          # argument...
+          if producer.is_a?(Integer)
+            # Record in the producing instruction that it produces a value
+            # used by this construction.
+            producer_dataflow = insn_flow[producer]
+            producer_dataflow.out << insn_pc
+          end
+        end
+      end
+    end
+
+    # Graph dataflow between basic blocks.
+    def global_flow
+      # Go through a worklist of all basic blocks...
+      worklist = cfg.blocks.dup
+      until worklist.empty?
+        succ = worklist.pop
+        succ_flow = block_flow[succ.start]
+        succ.preds.each do |pred|
+          pred_flow = block_flow[pred.start]
+
+          # Does a predecessor block have fewer outputs than the successor
+          # has inputs?
+          if pred_flow.out.size < succ_flow.in.size
+            # If so then add arguments to pass data through from the
+            # predecessor's redecessors.
+            (succ_flow.in.size - pred_flow.out.size).times do |n|
+              name = :"pass_#{n}"
+              pred_flow.in.unshift name
+              pred_flow.out.unshift name
+            end
+
+            # Since we modified the predecessor, add it back to the worklist
+            # so it'll be considered as a successor again, and propogate
+            # the global dataflow back up the control flow graph.
+            worklist.push pred
+          end
+        end
+      end
+    end
+
+    def verify_flow
+      # Check the first block has no arguments.
+      first_block = cfg.blocks.first
+      first_blow_flow = block_flow[first_block.start]
+      raise unless first_blow_flow.in.size == 0
+
+      # Check all control flow edges between blocks pass the right number of
+      # arguments.
+      cfg.blocks.each do |pred|
+        pred_flow = block_flow[pred.start]
+        if pred.succs.empty?
+          # With no successors, there should be no output arguments.
+          raise unless pred_flow.out.empty?
+        else
+          # Check with successor...
+          pred.succs.each do |succ|
+            succ_block = cfg.block_map[succ]
+            succ_flow = block_flow[succ.start]
+            # The predecessor should have as many output arguments as the
+            # success has input arguments.
+            raise unless pred_flow.out.size == succ_flow.in.size
+          end
+        end
+      end
+    end
+
+    def disasm(output = StringIO.new, prefix = "")
+      output.puts prefix + cfg.iseq.disasm_header("dfg")
+      cfg.blocks.each do |block|
+        block_dataflow = block_flow[block.start]
+        block.disasm_block_header output, prefix
+        unless block_dataflow.in.empty?
+          output.print prefix
+          output.puts "        # in: #{disasm_dataflow_connections(block_dataflow.in)}"
+        end
+        block.disasm_block_body output, prefix do |insn, rel_pc|
+          insn_pc = block.start + rel_pc
+          insn_dataflow = insn_flow[insn_pc]
+          if insn_dataflow.in.empty? && insn_dataflow.out.empty?
+            ""
+          else
+            annotate = " # "
+            unless insn_dataflow.in.empty?
+              annotate += "in: #{disasm_dataflow_connections(insn_dataflow.in)}"
+              annotate += "; " unless insn_dataflow.out.empty?
+            end
+            unless insn_dataflow.out.empty?
+              annotate +=
+                "out: #{disasm_dataflow_connections(insn_dataflow.out)}"
+            end
+            annotate
+          end
+        end
+        unless block_dataflow.out.empty?
+          output.print prefix
+          output.puts "        # out: #{disasm_dataflow_connections(block_dataflow.out)}"
+        end
+      end
+      output.string
+    end
+
+    def disasm_dataflow_connections(connections)
+      connections
+        .map { |pc| pc.is_a?(Symbol) ? pc : cfg.iseq.disasm_pc(pc) }
+        .join(", ")
+    end
+
+    class Dataflow
+      attr_reader :in
+      attr_reader :out
+
+      def initialize
+        @in = []
+        @out = []
+      end
+    end
+  end
+end

--- a/lib/yarv/insn/branchif.rb
+++ b/lib/yarv/insn/branchif.rb
@@ -53,6 +53,14 @@ module YARV
       true
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       target = iseq ? iseq.labels[label] : "??"
       "%-38s %s (%s)" % ["branchif", label, target]

--- a/lib/yarv/insn/branchunless.rb
+++ b/lib/yarv/insn/branchunless.rb
@@ -53,6 +53,14 @@ module YARV
       true
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       target = iseq ? iseq.labels[label] : "??"
       "%-38s %s (%s)" % ["branchunless", label, target]

--- a/lib/yarv/insn/definemethod.rb
+++ b/lib/yarv/insn/definemethod.rb
@@ -37,6 +37,14 @@ module YARV
       { name:, iseq: }
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      0
+    end
+
     def disasm(containing_iseq)
       "%-38s %s, %s" % ["definemethod", name.inspect, iseq.name]
     end

--- a/lib/yarv/insn/getlocal_wc_0.rb
+++ b/lib/yarv/insn/getlocal_wc_0.rb
@@ -35,6 +35,14 @@ module YARV
       context.stack.push(value)
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def deconstruct_keys(keys)
       { name:, index: }
     end

--- a/lib/yarv/insn/jump.rb
+++ b/lib/yarv/insn/jump.rb
@@ -45,6 +45,14 @@ module YARV
       true
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       target = iseq ? iseq.labels[label] : "??"
       "%-38s %s (%s)" % ["jump", label, target]

--- a/lib/yarv/insn/leave.rb
+++ b/lib/yarv/insn/leave.rb
@@ -32,6 +32,14 @@ module YARV
       true
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       "leave"
     end

--- a/lib/yarv/insn/opt_gt.rb
+++ b/lib/yarv/insn/opt_gt.rb
@@ -37,6 +37,14 @@ module YARV
       { call_data: }
     end
 
+    def reads
+      2
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "%-38s %s%s" % ["opt_gt", call_data, "[CcCr]"]
     end

--- a/lib/yarv/insn/opt_lt.rb
+++ b/lib/yarv/insn/opt_lt.rb
@@ -33,6 +33,14 @@ module YARV
       context.stack.push(result)
     end
 
+    def reads
+      2
+    end
+
+    def writes
+      1
+    end
+
     def deconstruct_keys(keys)
       { call_data: }
     end

--- a/lib/yarv/insn/opt_minus.rb
+++ b/lib/yarv/insn/opt_minus.rb
@@ -35,6 +35,14 @@ module YARV
       context.stack.push(result)
     end
 
+    def reads
+      2
+    end
+
+    def writes
+      1
+    end
+
     def deconstruct_keys(keys)
       { call_data: }
     end

--- a/lib/yarv/insn/opt_plus.rb
+++ b/lib/yarv/insn/opt_plus.rb
@@ -39,6 +39,14 @@ module YARV
       { call_data: }
     end
 
+    def reads
+      2
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "%-38s %s%s" % ["opt_plus", call_data, "[CcCr]"]
     end

--- a/lib/yarv/insn/opt_send_without_block.rb
+++ b/lib/yarv/insn/opt_send_without_block.rb
@@ -38,6 +38,14 @@ module YARV
       { call_data: }
     end
 
+    def reads
+      call_data.argc + 1
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "%-38s %s" % ["opt_send_without_block", call_data]
     end

--- a/lib/yarv/insn/pop.rb
+++ b/lib/yarv/insn/pop.rb
@@ -24,6 +24,14 @@ module YARV
       context.stack.pop
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       "pop"
     end

--- a/lib/yarv/insn/putnil.rb
+++ b/lib/yarv/insn/putnil.rb
@@ -24,6 +24,14 @@ module YARV
       context.stack.push(nil)
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "putnil"
     end

--- a/lib/yarv/insn/putobject.rb
+++ b/lib/yarv/insn/putobject.rb
@@ -34,6 +34,14 @@ module YARV
       { object: }
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "%-38s %s" % ["putobject", object.inspect]
     end

--- a/lib/yarv/insn/putobject_int2fix_0.rb
+++ b/lib/yarv/insn/putobject_int2fix_0.rb
@@ -26,6 +26,14 @@ module YARV
       context.stack.push(0)
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "putobject_INT2FIX_0_"
     end

--- a/lib/yarv/insn/putobject_int2fix_1.rb
+++ b/lib/yarv/insn/putobject_int2fix_1.rb
@@ -26,6 +26,14 @@ module YARV
       context.stack.push(1)
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def disasm(iseq)
       "putobject_INT2FIX_1_"
     end

--- a/lib/yarv/insn/putself.rb
+++ b/lib/yarv/insn/putself.rb
@@ -30,6 +30,14 @@ module YARV
       context.stack.push(object)
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def deconstruct_keys(keys)
       { object: }
     end

--- a/lib/yarv/insn/setlocal_wc_0.rb
+++ b/lib/yarv/insn/setlocal_wc_0.rb
@@ -34,6 +34,14 @@ module YARV
       context.current_frame.set_local(index, value)
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       "%-38s %s@%d" % ["setlocal_WC_0", name, index]
     end

--- a/lib/yarv/insn/setlocal_wc_1.rb
+++ b/lib/yarv/insn/setlocal_wc_1.rb
@@ -35,6 +35,14 @@ module YARV
       context.parent_frame.set_local(index, value)
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      0
+    end
+
     def disasm(iseq)
       "%-38s %s@%d" % ["setlocal_WC_1", name, index]
     end

--- a/lib/yarv/instruction.rb
+++ b/lib/yarv/instruction.rb
@@ -19,6 +19,16 @@ module YARV
       false
     end
 
+    # How many values are read from the stack.
+    def reads
+      raise "not implemented #{self.class}"
+    end
+
+    # How many values are written to the stack.
+    def writes
+      raise "not implemented #{self.class}"
+    end
+
     # A hook method to be called when the instruction is being disassembled. The
     # child classes will have their respective InstructionSequence passed in.
     def to_s

--- a/lib/yarv/instruction_sequence.rb
+++ b/lib/yarv/instruction_sequence.rb
@@ -408,7 +408,11 @@ module YARV
     end
 
     def disasm_insn(insn, insn_pc)
-      "#{insn_pc.to_s.rjust(4, "0")} #{insn.disasm(self)}"
+      "#{disasm_pc(insn_pc)} #{insn.disasm(self)}"
+    end
+
+    def disasm_pc(pc)
+      pc.to_s.rjust(4, "0")
     end
 
     # This is the name assigned to this instruction sequence.

--- a/test/dfg_test.rb
+++ b/test/dfg_test.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module YARV
+  class DFGTest < Test::Unit::TestCase
+    # Only uses local dataflow.
+    def test_local
+      assert_dfg(<<~DISASM, "14 + 2")
+        == dfg #<ISeq:<compiled>>
+        block_0:
+            0000 putobject                              14 # out: 0002
+            0001 putobject                              2 # out: 0002
+            0002 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr] # in: 0001, 0000; out: 0003
+            0003 leave # in: 0002
+                # to: leaves
+      DISASM
+    end
+
+    # Triggers a simple basic block argument - the value for the add may come
+    # from either side of the ternary.
+    def test_simple_bbarg
+      assert_dfg(<<~DISASM, "(14 < 0 ? -1 : +1) + 100")
+        == dfg #<ISeq:<compiled>>
+        block_0:
+            0000 putobject                              14 # out: 0002
+            0001 putobject_INT2FIX_0_ # out: 0002
+            0002 opt_lt                                 <calldata!mid:<, argc:1, ARGS_SIMPLE>[CcCr] # in: 0001, 0000; out: 0003
+            0003 branchunless                           label_11 (6) # in: 0002
+                # to: block_6, block_4
+        block_4: # from: block_0
+            0004 putobject                              -1 # out: out_0
+            0005 jump                                   label_12 (7)
+                # to: block_7
+                # out: 0004
+        block_6: # from: block_0
+            0006 putobject_INT2FIX_1_ # out: out_0
+                # to: block_7
+                # out: 0006
+        block_7: # from: block_4, block_6
+                # in: in_0
+            0007 putobject                              100 # out: 0008
+            0008 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr] # in: 0007, in_0; out: 0009
+            0009 leave # in: 0008
+                # to: leaves
+      DISASM
+    end
+
+    # Triggers an indirect basic block argument - the 100 value for the add
+    # comes from block_0, and is used in block_8, but they aren't directly
+    # connected. This should cause the basic blocks in between to take the
+    # value as an input and pass it directly as an output.
+    def test_indirect_bbarg
+      assert_dfg(<<~DISASM, "100 + (14 < 0 ? -1 : +1)")
+        == dfg #<ISeq:<compiled>>
+        block_0:
+            0000 putobject                              100 # out: out_0
+            0001 putobject                              14 # out: 0003
+            0002 putobject_INT2FIX_0_ # out: 0003
+            0003 opt_lt                                 <calldata!mid:<, argc:1, ARGS_SIMPLE>[CcCr] # in: 0002, 0001; out: 0004
+            0004 branchunless                           label_13 (7) # in: 0003
+                # to: block_7, block_5
+                # out: 0000
+        block_5: # from: block_0
+                # in: pass_0
+            0005 putobject                              -1 # out: out_0
+            0006 jump                                   label_14 (8)
+                # to: block_8
+                # out: pass_0, 0005
+        block_7: # from: block_0
+                # in: pass_0
+            0007 putobject_INT2FIX_1_ # out: out_0
+                # to: block_8
+                # out: pass_0, 0007
+        block_8: # from: block_5, block_7
+                # in: in_0, in_1
+            0008 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr] # in: in_0, in_1; out: 0009
+            0009 leave # in: 0008
+                # to: leaves
+      DISASM
+    end
+
+    def test_loop
+      source = <<~SOURCE
+        n = 10
+        sum = 0
+        while n > 0
+          sum += n
+          n -= 1
+        end
+        sum
+      SOURCE
+      assert_dfg(<<~DISASM, source)
+        == dfg #<ISeq:<compiled>>
+        block_0:
+            0000 putobject                              10 # out: 0001
+            0001 setlocal_WC_0                          n@0 # in: 0000
+            0002 putobject_INT2FIX_0_ # out: 0003
+            0003 setlocal_WC_0                          sum@1 # in: 0002
+            0004 jump                                   label_28 (16)
+            0005 putnil # out: 0006
+            0006 pop # in: 0005
+            0007 jump                                   label_28 (16)
+                # to: block_16
+        block_8: # from: block_16
+            0008 getlocal_WC_0                          sum@1 # out: 0010
+            0009 getlocal_WC_0                          n@0 # out: 0010
+            0010 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr] # in: 0009, 0008; out: 0011
+            0011 setlocal_WC_0                          sum@1 # in: 0010
+            0012 getlocal_WC_0                          n@0 # out: 0014
+            0013 putobject_INT2FIX_1_ # out: 0014
+            0014 opt_minus                              <calldata!mid:-, argc:1, ARGS_SIMPLE>[CcCr] # in: 0013, 0012; out: 0015
+            0015 setlocal_WC_0                          n@0 # in: 0014
+                # to: block_16
+        block_16: # from: block_0, block_8
+            0016 getlocal_WC_0                          n@0 # out: 0018
+            0017 putobject_INT2FIX_0_ # out: 0018
+            0018 opt_gt                                 <calldata!mid:>, argc:1, ARGS_SIMPLE>[CcCr] # in: 0017, 0016; out: 0019
+            0019 branchif                               label_13 (8) # in: 0018
+                # to: block_8, block_20
+        block_20: # from: block_16
+            0020 putnil # out: 0021
+            0021 pop # in: 0020
+            0022 getlocal_WC_0                          sum@1 # out: 0023
+            0023 leave # in: 0022
+                # to: leaves
+      DISASM
+    end
+
+    def test_fib
+      source = <<~SOURCE
+        def fib(n)
+          if n < 2
+            n
+          else
+            fib(n - 1) + fib(n - 2)
+          end
+        end
+      SOURCE
+      assert_dfg(<<~DISASM, source)
+        == dfg #<ISeq:<compiled>>
+        block_0:
+            0000 definemethod                           :fib, fib
+            0001 putobject                              :fib # out: 0002
+            0002 leave # in: 0001
+                # to: leaves
+        == dfg #<ISeq:fib>
+        block_0:
+            0000 getlocal_WC_0                          n@0 # out: 0002
+            0001 putobject                              2 # out: 0002
+            0002 opt_lt                                 <calldata!mid:<, argc:1, ARGS_SIMPLE>[CcCr] # in: 0001, 0000; out: 0003
+            0003 branchunless                           label_11 (6) # in: 0002
+                # to: block_6, block_4
+        block_4: # from: block_0
+            0004 getlocal_WC_0                          n@0 # out: 0005
+            0005 leave # in: 0004
+                # to: leaves
+        block_6: # from: block_0
+            0006 putself # out: 0010
+            0007 getlocal_WC_0                          n@0 # out: 0009
+            0008 putobject_INT2FIX_1_ # out: 0009
+            0009 opt_minus                              <calldata!mid:-, argc:1, ARGS_SIMPLE>[CcCr] # in: 0008, 0007; out: 0010
+            0010 opt_send_without_block                 <calldata!mid:fib, argc:1, FCALL|ARGS_SIMPLE> # in: 0009, 0006; out: 0016
+            0011 putself # out: 0015
+            0012 getlocal_WC_0                          n@0 # out: 0014
+            0013 putobject                              2 # out: 0014
+            0014 opt_minus                              <calldata!mid:-, argc:1, ARGS_SIMPLE>[CcCr] # in: 0013, 0012; out: 0015
+            0015 opt_send_without_block                 <calldata!mid:fib, argc:1, FCALL|ARGS_SIMPLE> # in: 0014, 0011; out: 0016
+            0016 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr] # in: 0015, 0010; out: 0017
+            0017 leave # in: 0016
+                # to: leaves
+      DISASM
+    end
+
+    private
+
+    def assert_dfg(expected, source)
+      string = +""
+      compiled = YARV.compile(source)
+      compiled.all_iseqs.each do |iseq|
+        cfg = YARV::CFG.new(iseq)
+        dfg = YARV::DFG.new(cfg)
+        string << dfg.disasm
+      end
+      assert_equal(expected, string)
+    end
+  end
+end


### PR DESCRIPTION
For example:

```ruby
(14 < 0 ? -1 : +1) + 100
```

```
== dfg #<ISeq:<compiled>>
block_0:
    0000 putobject                              14 # out: 0002
    0001 putobject_INT2FIX_0_ # out: 0002
    0002 opt_lt                                 <calldata!mid:<, argc:1, ARGS_SIMPLE>[CcCr] # in: 0001, 0000; out: 0003
    0003 branchunless                           label_11 (6) # in: 0002
        # to: block_6, block_4
block_4: # from: block_0
    0004 putobject                              -1 # out: out_0
    0005 jump                                   label_12 (7)
        # to: block_7
        # out: 0004
block_6: # from: block_0
    0006 putobject_INT2FIX_1_ # out: out_0
        # to: block_7
        # out: 0006
block_7: # from: block_4, block_6
        # in: in_0
    0007 putobject                              100 # out: 0008
    0008 opt_plus                               <calldata!mid:+, argc:1, ARGS_SIMPLE>[CcCr] # in: 0007, in_0; out: 0009
    0009 leave # in: 0008
        # to: leaves
```

Breaking this down:

```
    0000 putobject                              14 # out: 0002
                                                     ^^^^^^^^^
      the result of this instruction is used by instruction 0002

    0002 opt_lt                                 <calldata!mid:<, argc:1, ARGS_SIMPLE>[CcCr] # in: 0001, 0000; out: 0003
                                                                                              ^^^^^^^^^^^^^^
      this instruction uses values produced by instructions 0001 and 0002
    
    
block_4: # from: block_0
    0004 putobject                              -1 # out: out_0
    0005 jump                                   label_12 (7)
        # to: block_7
        # out: 0004
          ^^^^^^^^^
      this basic block passes the value produced by instruction 0004 to the successor basic block

block_7: # from: block_4, block_6
        # in: in_0
          ^^^^^^^^
      this basic block takes a value produced by the predecessor basic block
```

Things that are a big vague still are the order of values. But this is enough to follow the dataflow (just not execute with it.)