### PR TITLE
Start to test based off RubySpec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@master
+        with:
+          submodules: recursive
 
       - name: Set up Ruby 💎
         uses: ruby/setup-ruby@v1

--- a/lib/yarv/dfg.rb
+++ b/lib/yarv/dfg.rb
@@ -142,7 +142,6 @@ module YARV
         else
           # Check with successor...
           pred.succs.each do |succ|
-            succ_block = cfg.block_map[succ]
             succ_flow = block_flow[succ.start]
             # The predecessor should have as many output arguments as the
             # success has input arguments.

--- a/lib/yarv/insn/dup.rb
+++ b/lib/yarv/insn/dup.rb
@@ -28,6 +28,10 @@ module YARV
       2
     end
 
+    def side_effects?
+      false
+    end
+
     def call(context)
       value = context.stack.pop
       context.stack.push(value)

--- a/lib/yarv/insn/dup.rb
+++ b/lib/yarv/insn/dup.rb
@@ -20,6 +20,14 @@ module YARV
       other in Dup
     end
 
+    def reads
+      1
+    end
+
+    def writes
+      2
+    end
+
     def call(context)
       value = context.stack.pop
       context.stack.push(value)

--- a/lib/yarv/insn/expandarray.rb
+++ b/lib/yarv/insn/expandarray.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module YARV
+  # ### Summary
+  #
+  # `expandarray` looks at the top of the stack, and if the value is an array
+  # it replaces it on the stack with `num` elements of the array, or `nil` if
+  # the elements are missing.
+  #
+  # ### TracePoint
+  #
+  # `dup` does not dispatch any events.
+  #
+  class ExpandArray < Instruction
+    attr_reader :size, :flag
+
+    def initialize(size, flag)
+      @size = size
+      @flag = flag
+    end
+
+    def ==(other)
+      other in ExpandArray[size: ^(size), flag: ^(flag)]
+    end
+
+    def call(context)
+      raise # see vm_expandarray, it's a little subtle
+    end
+
+    def reads
+      1
+    end
+
+    def writes
+      size
+    end
+
+    def disasm(iseq)
+      "%-38s %d, %d" % ["expandarray", size, flag]
+    end
+
+    def deconstruct_keys(keys)
+      { size:, flag: }
+    end
+  end
+end

--- a/lib/yarv/insn/nop.rb
+++ b/lib/yarv/insn/nop.rb
@@ -21,6 +21,14 @@ module YARV
       other in Nop
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      0
+    end
+
     def call(context)
     end
 

--- a/lib/yarv/insn/nop.rb
+++ b/lib/yarv/insn/nop.rb
@@ -29,6 +29,10 @@ module YARV
       0
     end
 
+    def side_effects?
+      false
+    end
+
     def call(context)
     end
 

--- a/lib/yarv/insn/opt_eq.rb
+++ b/lib/yarv/insn/opt_eq.rb
@@ -26,6 +26,14 @@ module YARV
       other in OptEq[call_data: ^(call_data)]
     end
 
+    def reads
+      2
+    end
+
+    def writes
+      1
+    end
+
     def call(context)
       receiver, *arguments = context.stack.pop(call_data.argc + 1)
       result = context.call_method(call_data, receiver, arguments)

--- a/lib/yarv/insn/putstring.rb
+++ b/lib/yarv/insn/putstring.rb
@@ -26,6 +26,14 @@ module YARV
       other in PutString[string: ^(string)]
     end
 
+    def reads
+      0
+    end
+
+    def writes
+      1
+    end
+
     def call(context)
       context.stack.push(string)
     end

--- a/lib/yarv/insn/send.rb
+++ b/lib/yarv/insn/send.rb
@@ -40,6 +40,14 @@ module YARV
       other in Send[call_data: ^(call_data), block_iseq: ^(block_iseq)]
     end
 
+    def reads
+      call_data.argc + 1
+    end
+
+    def writes
+      1
+    end
+
     def call(context)
       receiver, *arguments = context.stack.pop(call_data.argc + 1)
       result =

--- a/lib/yarv/instruction_sequence.rb
+++ b/lib/yarv/instruction_sequence.rb
@@ -119,7 +119,7 @@ module YARV
           in :dupn, offset
             compiled << DupN.new(offset)
           in :expandarray, size, flag
-            compiled << UnimplementedInstruction.new("expandarray", size, flag)
+            compiled << ExpandArray.new(size, flag)
           in :getblockparam, index, level
             compiled << UnimplementedInstruction.new(
               "getblockparam",

--- a/test/spec_test.rb
+++ b/test/spec_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module YARV
+  class SpecTest < Test::Unit::TestCase
+    # We're not stupid, we just want to cache results from previous tests for
+    # use in subsequent tests in COMPILED_CACHE, CFG_CACHE etc.
+    self.test_order = :defined
+
+    SPEC_FILES = ["#{__dir__}/../spec/ruby/language/and_spec.rb"]
+
+    COMPILED_CACHE = {}
+    CFG_CACHE = {}
+    DFG_CACHE = {}
+    SOY_CACHE = {}
+
+    def test_compile
+      SPEC_FILES.each do |spec_file|
+        compiled =
+          without_warnings do
+            YARV.compile(
+              File.read(spec_file),
+              spec_file,
+              File.basename(spec_file)
+            )
+          end
+        COMPILED_CACHE[spec_file] = compiled
+      end
+    end
+
+    def test_disasm
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.disasm
+      end
+    end
+
+    def test_cfg
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.all_iseqs.each do |iseq|
+          iseq_key = [spec_file, iseq.object_id]
+          cfg = CFG.new(iseq)
+          CFG_CACHE[iseq_key] = cfg
+        end
+      end
+    end
+
+    def test_cfg_disasm
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.all_iseqs.each do |iseq|
+          iseq_key = [spec_file, iseq.object_id]
+          cfg = CFG_CACHE[iseq_key]
+          next unless cfg
+          cfg.disasm
+        end
+      end
+    end
+
+    def test_dfg
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.all_iseqs.each do |iseq|
+          iseq_key = [spec_file, iseq.object_id]
+          cfg = CFG_CACHE[iseq_key]
+          next unless cfg
+          dfg = YARV::DFG.new(cfg)
+          DFG_CACHE[iseq_key] = dfg
+        end
+      end
+    end
+
+    def test_dfg_disasm
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.all_iseqs.each do |iseq|
+          iseq_key = [spec_file, iseq.object_id]
+          dfg = DFG_CACHE[iseq_key]
+          next unless dfg
+          dfg.disasm
+        end
+      end
+    end
+
+    def test_soy
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.all_iseqs.each do |iseq|
+          iseq_key = [spec_file, iseq.object_id]
+          dfg = DFG_CACHE[iseq_key]
+          next unless dfg
+          soy = YARV::SOY.new(dfg)
+          SOY_CACHE[iseq_key] = soy
+        end
+      end
+    end
+
+    def test_soy_mermaid
+      SPEC_FILES.each do |spec_file|
+        compiled = COMPILED_CACHE[spec_file]
+        next unless compiled
+        compiled.all_iseqs.each do |iseq|
+          iseq_key = [spec_file, iseq.object_id]
+          soy = SOY_CACHE[iseq_key]
+          next unless soy
+          soy.mermaid
+        end
+      end
+    end
+
+    def without_warnings
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      begin
+        yield
+      ensure
+        $VERBOSE = original_verbose
+      end
+    end
+  end
+end

--- a/test/static_spec_test.rb
+++ b/test/static_spec_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 module YARV
-  class SpecTest < Test::Unit::TestCase
+  class StaticSpecTest < Test::Unit::TestCase
     # We're not stupid, we just want to cache results from previous tests for
     # use in subsequent tests in COMPILED_CACHE, CFG_CACHE etc.
     self.test_order = :defined


### PR DESCRIPTION
Let's start to test that we can handle files from the RubySpec suite. We can hard-code files to start with, before eventually globbing `**/*.rb`.

At the moment we're just creating our data structures, but in the future we can run interpreters on the code as well.