### PR TITLE
Add ruby example to expandarray instruction

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -24,8 +24,14 @@ filepaths.each do |filepath|
 
   # Extract the ruby code block from the comments, generate the instruction
   # sequence for it, and then inject the commented sequence into the block
-  ruby_code = formatted_comments.match(/~~~ruby\n([\S\s]*)~~~/)[1]
+  ruby_code_match = formatted_comments.match(/~~~ruby\n([\S\s]*)~~~/)
 
+  if ruby_code_match.nil?
+    raise "Missing ruby example in #{filepath} doc comment"
+  else
+    ruby_code = ruby_code_match[1]
+  end
+  
   disasm = RubyVM::InstructionSequence.new(ruby_code).disasm
   disasm.gsub!(/^/, "# ")
 

--- a/lib/yarv/insn/expandarray.rb
+++ b/lib/yarv/insn/expandarray.rb
@@ -9,7 +9,13 @@ module YARV
   #
   # ### TracePoint
   #
-  # `dup` does not dispatch any events.
+  # `expandarray` does not dispatch any events.
+  #
+  # ### Usage
+  #
+  # ~~~ruby
+  # x, = [true, false, nil]
+  # ~~~
   #
   class ExpandArray < Instruction
     attr_reader :size, :flag


### PR DESCRIPTION
Also update the doc generation script so missing ruby examples output a better error message:

Before:

```
bin/doc:27:in `block in <main>': undefined method `[]' for nil:NilClass (NoMethodError)

  ruby_code = formatted_comments.match(/~~~ruby\\n([\\S\\s]*)~~~/)[1]
                                                               ^^^
        from bin/doc:17:in `each'
        from bin/doc:17:in `<main>'
```

After:

```
bin/doc:30:in `block in <main>': Missing ruby example in /Users/hartley/src/github.com/kddnewton/yarv/lib/yarv/insn/expandarray.rb doc comment (RuntimeError)
        from bin/doc:17:in `each'
        from bin/doc:17:in `<main>'
```
