### PR TITLE
Properly end code block for send

### DIFF
--- a/lib/yarv/insn/send.rb
+++ b/lib/yarv/insn/send.rb
@@ -26,7 +26,7 @@ module YARV
   # # 0001 getlocal_WC_0                          i@0
   # # 0003 opt_send_without_block                 <calldata!mid:p, argc:1, FCALL|ARGS_SIMPLE>
   # # 0005 leave                                  [Br]
-  # # ~~~
+  # ~~~
   #
   class Send < Instruction
     attr_reader :call_data, :block_iseq


### PR DESCRIPTION
Send bleeds into set global on the docs page. Seems to be because of the extra level of comments there. (didn't test this locally)

<img width="1159" alt="Screen Shot 2022-10-24 at 12 22 10 AM" src="https://user-images.githubusercontent.com/6071338/197448095-22ce3339-f65b-4d4b-a0ba-3350f8fceb1a.png">
